### PR TITLE
feat: add typed env config

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -1,0 +1,23 @@
+import 'dotenv/config';
+import { z } from 'zod';
+
+const envSchema = z.object({
+  RPC_HTTP_URL: z.string().url(),
+  RPC_WSS_URL: z.string().url(),
+  CHAIN_ID: z.coerce.number().int().positive(),
+  WS_PORT: z.coerce.number().int().default(8080),
+  LOG_LEVEL: z.enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace']).default('info'),
+  METRICS_PORT: z.coerce.number().int().default(9108),
+});
+
+const parsedEnv = envSchema.safeParse(process.env);
+
+if (!parsedEnv.success) {
+  const { fieldErrors } = parsedEnv.error.flatten();
+  throw new Error(
+    `Invalid environment variables:\n${JSON.stringify(fieldErrors, null, 2)}`
+  );
+}
+
+export const env = parsedEnv.data;
+export type Env = z.infer<typeof envSchema>;


### PR DESCRIPTION
## Summary
- add backend env loader using dotenv and zod for validation

## Testing
- `pnpm --filter backend lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `pnpm --filter backend exec vitest run` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68995aba8c34832a8029570ed0224780