### PR TITLE
feat(backend): add pino logger utility

### DIFF
--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,0 +1,39 @@
+import pino from 'pino';
+import { env } from '../config/env';
+
+/**
+ * Pino logger instance configured with application log level.
+ * Logs are JSON formatted and include pid and timestamp.
+ */
+export const logger = pino({
+  level: env.LOG_LEVEL,
+  base: { pid: process.pid },
+  timestamp: pino.stdTimeFunctions.isoTime,
+});
+
+/**
+ * Log an event coming from a DEX.
+ *
+ * @param dex   Name of the DEX.
+ * @param pair  Trading pair symbol.
+ * @param block Block number where the event was observed.
+ */
+export const logDexEvent = (
+  dex: string,
+  pair: string,
+  block: number,
+): void => {
+  logger.info({ dex, pair, block }, 'dex event');
+};
+
+/**
+ * Log an error that occurred during a particular stage.
+ *
+ * @param stage Description of the stage or operation.
+ * @param error The error instance or message.
+ */
+export const logError = (stage: string, error: unknown): void => {
+  logger.error({ stage, err: error }, 'error encountered');
+};
+
+export default logger;


### PR DESCRIPTION
## Summary
- add reusable pino logger configured via env
- helper logging methods for DEX events and error stages

## Testing
- `pnpm -F backend lint` *(fails: ESLint couldn't find configuration file)*
- `CI=1 pnpm -F backend test --run` *(fails: No test files found, exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68995c15bc98832a95e46f393963b4c1