### PR TITLE
feat: add websocket server for token metadata updates

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,5 @@
 import './monitoring/metrics';
+import './server/wsServer';
 import { logger } from './utils/logger';
 
 logger.info('Backend running');

--- a/backend/src/server/wsServer.ts
+++ b/backend/src/server/wsServer.ts
@@ -1,0 +1,57 @@
+import WebSocket, { WebSocketServer } from 'ws';
+import { z } from 'zod';
+
+import { env } from '../config/env';
+import { wsClientsActive, broadcastMsgsTotal } from '../monitoring/metrics';
+import { logger } from '../utils/logger';
+
+// Zod schemas for token metadata updates
+const tokenMetaSchema = z.object({
+  address: z.string(),
+  symbol: z.string(),
+  decimals: z.number(),
+});
+
+const tokenMetaUpdateSchema = z.object({
+  type: z.literal('tokenMeta.update'),
+  payload: z.record(tokenMetaSchema),
+});
+
+export type TokenMeta = z.infer<typeof tokenMetaSchema>;
+export type TokenMetaUpdate = z.infer<typeof tokenMetaUpdateSchema>;
+
+let snapshot: Record<string, TokenMeta> = {};
+
+const wss = new WebSocketServer({ port: env.WS_PORT });
+logger.info(`WebSocket server listening on port ${env.WS_PORT}`);
+
+wss.on('connection', (ws) => {
+  wsClientsActive.inc();
+
+  const fullUpdate: TokenMetaUpdate = { type: 'tokenMeta.update', payload: snapshot };
+  const parsed = tokenMetaUpdateSchema.parse(fullUpdate);
+  ws.send(JSON.stringify(parsed));
+
+  ws.on('close', () => {
+    wsClientsActive.dec();
+  });
+});
+
+export function broadcast(update: TokenMetaUpdate): void {
+  const parsed = tokenMetaUpdateSchema.safeParse(update);
+  if (!parsed.success) {
+    logger.error({ err: parsed.error }, 'invalid token meta update');
+    return;
+  }
+
+  snapshot = { ...snapshot, ...parsed.data.payload };
+  const payload = JSON.stringify(parsed.data);
+
+  for (const client of wss.clients) {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(payload);
+      broadcastMsgsTotal.inc();
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- create WebSocket server to broadcast token metadata updates and track active clients
- hook WebSocket server into backend startup

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `pnpm test` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68995ef6effc832a848a5db77182f13d