### PR TITLE
feat: add basic HTTP server

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -6,6 +6,7 @@ const envSchema = z.object({
   RPC_WSS_URL: z.string().url(),
   CHAIN_ID: z.coerce.number().int().positive(),
   WS_PORT: z.coerce.number().int().default(8080),
+  HTTP_PORT: z.coerce.number().int().default(3000),
   LOG_LEVEL: z.enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace']).default('info'),
   METRICS_PORT: z.coerce.number().int().default(9108),
 });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,5 +1,6 @@
 import './monitoring/metrics';
 import './server/wsServer';
+import './server/http';
 import { logger } from './utils/logger';
 
 logger.info('Backend running');

--- a/backend/src/server/http.ts
+++ b/backend/src/server/http.ts
@@ -1,0 +1,46 @@
+import http from 'node:http';
+
+import { env } from '../config/env';
+import { logger } from '../utils/logger';
+
+const commit = process.env.COMMIT ?? 'unknown';
+const builtAt = process.env.BUILT_AT ?? new Date().toISOString();
+
+let latestBlock = 0;
+let trackedPairs: unknown[] = [];
+
+export function setLatestBlock(block: number): void {
+  latestBlock = block;
+}
+
+export function setTrackedPairs(pairs: unknown[]): void {
+  trackedPairs = pairs;
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/healthz') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status: 'ok', block: latestBlock }));
+    return;
+  }
+
+  if (req.method === 'GET' && req.url === '/version') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ commit, builtAt }));
+    return;
+  }
+
+  if (req.method === 'GET' && req.url === '/pairs') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(trackedPairs));
+    return;
+  }
+
+  res.writeHead(404);
+  res.end('Not Found');
+});
+
+server.listen(env.HTTP_PORT, '0.0.0.0', () => {
+  logger.info(`HTTP server listening on port ${env.HTTP_PORT}`);
+});
+


### PR DESCRIPTION
## Summary
- add minimal HTTP server with health, version, and tracked pair endpoints
- expose HTTP_PORT env config
- boot HTTP server on backend startup

## Testing
- `pnpm --filter backend exec vitest run --passWithNoTests`
- `pnpm --filter backend lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68996b6e983c832a954eb22f322e1d50