### PR TITLE
feat(frontend): add websocket state management

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_WS_URL=ws://localhost:8080

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "zustand": "^5.0.7"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,14 @@
-import React from "react";
+import React from 'react';
+import { useWebSocket } from './hooks/useWebSocket';
+import { useArbStore } from './useArbStore';
 
 export default function App() {
-  return <h1>Frontend</h1>;
+  useWebSocket();
+  const status = useArbStore((s) => s.status);
+  return (
+    <div>
+      <h1>Frontend</h1>
+      <p>Status: {status}</p>
+    </div>
+  );
 }

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { tokenMetaUpdateSchema } from '../../../packages/types/src';
+import { useArbStore } from '../useArbStore';
+
+export function useWebSocket() {
+  const addPair = useArbStore((s) => s.addPair);
+  const setStatus = useArbStore((s) => s.setStatus);
+
+  useEffect(() => {
+    const url = import.meta.env.VITE_WS_URL;
+    const ws = new WebSocket(url);
+
+    ws.onopen = () => setStatus('connected');
+    ws.onclose = () => setStatus('disconnected');
+    ws.onerror = () => setStatus('disconnected');
+
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        const parsed = tokenMetaUpdateSchema.parse(data);
+        addPair(parsed.payload);
+      } catch (err) {
+        console.error('Invalid message', err);
+      }
+    };
+
+    return () => {
+      ws.close();
+    };
+  }, [addPair, setStatus]);
+}

--- a/frontend/src/useArbStore.ts
+++ b/frontend/src/useArbStore.ts
@@ -1,0 +1,20 @@
+import { create } from 'zustand';
+import type { TokenMetaUpdate } from '../../packages/types/src';
+
+type Pair = TokenMetaUpdate['payload'];
+
+type Status = 'disconnected' | 'connected';
+
+interface ArbState {
+  pairs: Pair[];
+  status: Status;
+  addPair: (pair: Pair) => void;
+  setStatus: (status: Status) => void;
+}
+
+export const useArbStore = create<ArbState>((set) => ({
+  pairs: [],
+  status: 'disconnected',
+  addPair: (pair) => set((s) => ({ pairs: [...s.pairs, pair] })),
+  setStatus: (status) => set({ status }),
+}));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      zustand:
+        specifier: ^5.0.7
+        version: 5.0.7(@types/react@18.3.23)(react@18.3.1)
     devDependencies:
       '@types/react':
         specifier: ^18.3.3
@@ -1349,6 +1352,24 @@ packages:
   zod@4.0.17:
     resolution: {integrity: sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==}
 
+  zustand@5.0.7:
+    resolution: {integrity: sha512-Ot6uqHDW/O2VdYsKLLU8GQu8sCOM1LcoE8RwvLv9uuRT9s6SOHCKs0ZEOhxg+I1Ld+A1Q5lwx+UlKXXUoCZITg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@adraffy/ens-normalize@1.10.1': {}
@@ -2508,3 +2529,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@4.0.17: {}
+
+  zustand@5.0.7(@types/react@18.3.23)(react@18.3.1):
+    optionalDependencies:
+      '@types/react': 18.3.23
+      react: 18.3.1


### PR DESCRIPTION
## Summary
- initialize websocket URL via `.env`
- add zustand store for arb pairs and connection status
- implement `useWebSocket` hook to stream `TokenMetaUpdate`s into the store
- display connection status in app

## Testing
- `pnpm --filter frontend lint`
- `pnpm --filter frontend test`
- `pnpm --filter frontend build`


------
https://chatgpt.com/codex/tasks/task_e_68996d7ffc64832a9956b72932ec3fef