### PR TITLE
feat: add live pairs table

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { useWebSocket } from './hooks/useWebSocket';
-import { useArbStore } from './useArbStore';
+import LivePairsTable from './components/LivePairsTable';
 
 export default function App() {
   useWebSocket();
-  const status = useArbStore((s) => s.status);
   return (
     <div>
       <h1>Frontend</h1>
-      <p>Status: {status}</p>
+      <LivePairsTable />
     </div>
   );
 }

--- a/frontend/src/components/LivePairsTable.tsx
+++ b/frontend/src/components/LivePairsTable.tsx
@@ -1,0 +1,121 @@
+import React, { useMemo, useState } from 'react';
+import { useArbStore } from '../useArbStore';
+
+interface Row {
+  pair: string;
+  uniswapPrice?: number;
+  sushiswapPrice?: number;
+  spreadBps?: number;
+  liquidityUSD?: number;
+  lastUpdate?: string;
+}
+
+export default function LivePairsTable() {
+  const { pairs, status } = useArbStore((s) => ({ pairs: s.pairs, status: s.status }));
+  const [minLiquidity, setMinLiquidity] = useState(0);
+  const [minSpreadBps, setMinSpreadBps] = useState(0);
+
+  const rows = useMemo<Row[]>(() => {
+    const map = new Map<string, Row>();
+    for (const p of pairs) {
+      const existing = map.get(p.pairSymbol) ?? { pair: p.pairSymbol };
+      const price = Number(p.price);
+      const liquidity = p.liquidityUSD ? Number(p.liquidityUSD) : undefined;
+      if (p.dex === 'uniswap') existing.uniswapPrice = price;
+      if (p.dex === 'sushiswap') existing.sushiswapPrice = price;
+      if (liquidity !== undefined) existing.liquidityUSD = liquidity;
+      existing.lastUpdate = p.at;
+      map.set(p.pairSymbol, existing);
+    }
+    return Array.from(map.values()).map((r) => {
+      if (r.uniswapPrice != null && r.sushiswapPrice != null) {
+        r.spreadBps =
+          ((r.uniswapPrice - r.sushiswapPrice) /
+            ((r.uniswapPrice + r.sushiswapPrice) / 2)) * 10000;
+      }
+      return r;
+    });
+  }, [pairs]);
+
+  const filtered = rows.filter(
+    (r) =>
+      (r.liquidityUSD ?? 0) >= minLiquidity &&
+      (r.spreadBps ?? -Infinity) >= minSpreadBps,
+  );
+
+  const format = (n?: number) => (n != null ? n.toFixed(2) : '-');
+
+  const statusColor = status === 'connected' ? 'green' : 'red';
+
+  return (
+    <div>
+      <div style={{ display: 'flex', gap: '1rem', marginBottom: '1rem', alignItems: 'center' }}>
+        <span
+          style={{
+            padding: '0.25rem 0.5rem',
+            borderRadius: '0.5rem',
+            backgroundColor: statusColor,
+            color: 'white',
+          }}
+        >
+          {status}
+        </span>
+        <label>
+          Min Liquidity
+          <input
+            type="number"
+            value={minLiquidity}
+            onChange={(e) => setMinLiquidity(Number(e.target.value))}
+            style={{ marginLeft: '0.25rem' }}
+          />
+        </label>
+        <label>
+          Min Spread (bps)
+          <input
+            type="number"
+            value={minSpreadBps}
+            onChange={(e) => setMinSpreadBps(Number(e.target.value))}
+            style={{ marginLeft: '0.25rem' }}
+          />
+        </label>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Pair</th>
+            <th>Uniswap Price</th>
+            <th>SushiSwap Price</th>
+            <th>Spread (bps)</th>
+            <th>Liquidity USD</th>
+            <th>Last Update</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map((r) => (
+            <tr key={r.pair}>
+              <td>{r.pair}</td>
+              <td>{format(r.uniswapPrice)}</td>
+              <td>{format(r.sushiswapPrice)}</td>
+              <td
+                style={{
+                  color:
+                    r.spreadBps != null && r.spreadBps < 0
+                      ? 'red'
+                      : r.spreadBps != null && r.spreadBps > minSpreadBps
+                        ? 'green'
+                        : undefined,
+                }}
+              >
+                {r.spreadBps != null ? r.spreadBps.toFixed(2) : '-'}
+              </td>
+              <td>{format(r.liquidityUSD)}</td>
+              <td>
+                {r.lastUpdate ? new Date(r.lastUpdate).toLocaleTimeString() : '-'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -18,7 +18,7 @@ export function useWebSocket() {
       try {
         const data = JSON.parse(event.data);
         const parsed = tokenMetaUpdateSchema.parse(data);
-        addPair(parsed.payload);
+        addPair({ ...parsed.payload, at: parsed.at });
       } catch (err) {
         console.error('Invalid message', err);
       }

--- a/frontend/src/useArbStore.ts
+++ b/frontend/src/useArbStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import type { TokenMetaUpdate } from '../../packages/types/src';
 
-type Pair = TokenMetaUpdate['payload'];
+type Pair = TokenMetaUpdate['payload'] & { at: string };
 
 type Status = 'disconnected' | 'connected';
 


### PR DESCRIPTION
## Summary
- add LivePairsTable component to display pair pricing and liquidity data with filters
- store timestamped pair updates and expose websocket status pill
- compute cross-dex spread and color code large or negative values

## Testing
- `pnpm test` *(fails: No test files found, exiting with code 1)*
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68996fb459d4832a9b09b0e1b3ee490f