### PR TITLE
Add Docker and PM2 configuration for backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20-slim
+
+WORKDIR /app
+
+COPY package.json ./
+
+RUN npm install --omit=dev
+
+COPY dist ./dist
+
+EXPOSE 8080
+EXPOSE 9108
+
+CMD ["node", "dist/index.js"]

--- a/backend/pm2.config.json
+++ b/backend/pm2.config.json
@@ -1,0 +1,9 @@
+{
+  "apps": [
+    {
+      "name": "arb-engine",
+      "script": "dist/index.js",
+      "watch": false
+    }
+  ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+
+services:
+  backend:
+    build: ./backend
+    env_file: .env
+    ports:
+      - "8080:8080"
+      - "9108:9108"
+
+  # redis:
+  #   image: redis:7-alpine
+  #   ports:
+  #     - "6379:6379"


### PR DESCRIPTION
## Summary
- add Node 20 Dockerfile for backend installing production dependencies and exposing required ports
- include docker-compose setup with optional Redis service
- provide PM2 config to run backend directly

## Testing
- `pnpm test` (fails: No test files found)

------
https://chatgpt.com/codex/tasks/task_e_689971041460832abc1cd9ec4f9f901d