### PR TITLE
feat: add typed websocket server

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,8 @@
     "pino": "^9.8.0",
     "prom-client": "^15.1.3",
     "ws": "^8.18.3",
-    "zod": "^4.0.17"
+    "zod": "^4.0.17",
+    "@t-op-arb-bot/types": "workspace:*"
   },
   "devDependencies": {
     "eslint": "^9.33.0",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,7 @@
 import './monitoring/metrics';
-import './server/wsServer';
 import './server/http';
 import { logger } from './utils/logger';
+import { startWsServer } from './server/wsServer';
 
+startWsServer();
 logger.info('Backend running');

--- a/backend/src/monitoring/metrics.ts
+++ b/backend/src/monitoring/metrics.ts
@@ -7,7 +7,7 @@ import { logger } from '../utils/logger';
 collectDefaultMetrics({ register });
 
 // Gauge for active websocket clients
-export const wsClientsActive = new Gauge({
+export const wsClientsActiveGauge = new Gauge({
   name: 'ws_clients_active',
   help: 'Number of active WebSocket clients',
 });
@@ -26,7 +26,7 @@ export const dexFetchMs = new Histogram({
 });
 
 // Counter for broadcast messages total
-export const broadcastMsgsTotal = new Counter({
+export const broadcastMsgsTotalCounter = new Counter({
   name: 'broadcast_msgs_total',
   help: 'Total number of messages broadcast to clients',
 });

--- a/backend/src/server/wsServer.ts
+++ b/backend/src/server/wsServer.ts
@@ -1,57 +1,155 @@
-import WebSocket, { WebSocketServer } from 'ws';
-import { z } from 'zod';
-
+import { WebSocketServer, WebSocket } from 'ws';
 import { env } from '../config/env';
-import { wsClientsActive, broadcastMsgsTotal } from '../monitoring/metrics';
 import { logger } from '../utils/logger';
+import {
+  wsClientsActiveGauge,
+  broadcastMsgsTotalCounter,
+} from '../monitoring/metrics';
+import {
+  TokenMetaUpdate,
+  tokenMetaUpdateZ,
+} from '@t-op-arb-bot/types';
 
-// Zod schemas for token metadata updates
-const tokenMetaSchema = z.object({
-  address: z.string(),
-  symbol: z.string(),
-  decimals: z.number(),
-});
+/**
+ * An in-memory snapshot keyed by pairSymbol.
+ * On each update we upsert into this map. On client connect,
+ * we replay the snapshot (one `tokenMeta.update` per pair).
+ */
+const snapshot = new Map<string, TokenMetaUpdate['payload']>();
 
-const tokenMetaUpdateSchema = z.object({
-  type: z.literal('tokenMeta.update'),
-  payload: z.record(tokenMetaSchema),
-});
+/** Connected clients */
+const clients = new Set<WebSocket>();
 
-export type TokenMeta = z.infer<typeof tokenMetaSchema>;
-export type TokenMetaUpdate = z.infer<typeof tokenMetaUpdateSchema>;
+let wss: WebSocketServer | null = null;
 
-let snapshot: Record<string, TokenMeta> = {};
+/**
+ * Start the WebSocket server (idempotent).
+ * Returns a small control surface used by the engine.
+ */
+export function startWsServer(port = env.WS_PORT) {
+  if (wss) return controlSurface; // already started
 
-const wss = new WebSocketServer({ port: env.WS_PORT });
-logger.info(`WebSocket server listening on port ${env.WS_PORT}`);
+  wss = new WebSocketServer({ port });
+  logger.info({ port }, 'WS server listening');
+  wss.on('connection', handleConnection);
 
-wss.on('connection', (ws) => {
-  wsClientsActive.inc();
+  return controlSurface;
+}
 
-  const fullUpdate: TokenMetaUpdate = { type: 'tokenMeta.update', payload: snapshot };
-  const parsed = tokenMetaUpdateSchema.parse(fullUpdate);
-  ws.send(JSON.stringify(parsed));
+function handleConnection(ws: WebSocket) {
+  clients.add(ws);
+  wsClientsActiveGauge.inc();
 
   ws.on('close', () => {
-    wsClientsActive.dec();
+    clients.delete(ws);
+    wsClientsActiveGauge.dec();
   });
-});
 
-export function broadcast(update: TokenMetaUpdate): void {
-  const parsed = tokenMetaUpdateSchema.safeParse(update);
-  if (!parsed.success) {
-    logger.error({ err: parsed.error }, 'invalid token meta update');
-    return;
-  }
-
-  snapshot = { ...snapshot, ...parsed.data.payload };
-  const payload = JSON.stringify(parsed.data);
-
-  for (const client of wss.clients) {
-    if (client.readyState === WebSocket.OPEN) {
-      client.send(payload);
-      broadcastMsgsTotal.inc();
-    }
+  // Send full snapshot to the new client (one validated message per pair)
+  for (const payload of snapshot.values()) {
+    const update: TokenMetaUpdate = {
+      type: 'tokenMeta.update',
+      at: new Date().toISOString(),
+      payload,
+    };
+    safeSend(ws, update);
   }
 }
 
+/**
+ * Upsert a single pair payload into the snapshot by pairSymbol.
+ * This does not broadcast by itself—call `broadcastUpdate` to fan out.
+ */
+export function upsertSnapshot(payload: TokenMetaUpdate['payload']) {
+  snapshot.set(payload.pairSymbol, payload);
+}
+
+/**
+ * Broadcast a single validated TokenMetaUpdate to all clients.
+ */
+export function broadcastUpdate(payload: TokenMetaUpdate['payload']) {
+  const update: TokenMetaUpdate = {
+    type: 'tokenMeta.update',
+    at: new Date().toISOString(),
+    payload,
+  };
+
+  // Validate against canonical Zod schema before sending
+  const parsed = tokenMetaUpdateZ.safeParse(update);
+  if (!parsed.success) {
+    logger.error(
+      {
+        issues: parsed.error.issues,
+        payload,
+      },
+      'Refusing to broadcast invalid TokenMetaUpdate'
+    );
+    return;
+  }
+
+  const json = JSON.stringify(parsed.data);
+  let sent = 0;
+
+  for (const ws of clients) {
+    // Skip if socket not open
+    if (ws.readyState !== ws.OPEN) continue;
+    try {
+      ws.send(json);
+      sent++;
+    } catch (err) {
+      logger.warn({ err }, 'WS send failed');
+    }
+  }
+
+  if (sent > 0) {
+    broadcastMsgsTotalCounter.inc(sent);
+  }
+}
+
+/**
+ * Helper to validate + send to a single socket (used for snapshot replay).
+ */
+function safeSend(ws: WebSocket, update: TokenMetaUpdate) {
+  const parsed = tokenMetaUpdateZ.safeParse(update);
+  if (!parsed.success) {
+    logger.error(
+      { issues: parsed.error.issues, update },
+      'Snapshot message failed validation'
+    );
+    return;
+  }
+  try {
+    ws.send(JSON.stringify(parsed.data));
+    broadcastMsgsTotalCounter.inc(1);
+  } catch (err) {
+    logger.warn({ err }, 'WS snapshot send failed');
+  }
+}
+
+/**
+ * Optional lifecycle helpers
+ */
+export function stopWsServer() {
+  if (!wss) return;
+  for (const ws of clients) {
+    try {
+      ws.close();
+    } catch {}
+  }
+  clients.clear();
+  wsClientsActiveGauge.set(0);
+
+  wss.close();
+  wss = null;
+}
+
+/**
+ * A tiny control surface used by the engine/bootstrap code.
+ */
+export const controlSurface = {
+  start: startWsServer,
+  stop: stopWsServer,
+  upsertSnapshot,
+  broadcastUpdate,
+  getClientCount: () => clients.size,
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "zustand": "^5.0.7"
+    "zustand": "^5.0.7",
+    "@t-op-arb-bot/types": "workspace:*"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { tokenMetaUpdateSchema } from '../../../packages/types/src';
+import { tokenMetaUpdateZ } from '@t-op-arb-bot/types';
 import { useArbStore } from '../useArbStore';
 
 export function useWebSocket() {
@@ -17,7 +17,7 @@ export function useWebSocket() {
     ws.onmessage = (event) => {
       try {
         const data = JSON.parse(event.data);
-        const parsed = tokenMetaUpdateSchema.parse(data);
+        const parsed = tokenMetaUpdateZ.parse(data);
         addPair({ ...parsed.payload, at: parsed.at });
       } catch (err) {
         console.error('Invalid message', err);

--- a/frontend/src/useArbStore.ts
+++ b/frontend/src/useArbStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { TokenMetaUpdate } from '../../packages/types/src';
+import type { TokenMetaUpdate } from '@t-op-arb-bot/types';
 
 type Pair = TokenMetaUpdate['payload'] & { at: string };
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,38 +1,25 @@
-import { z } from "zod";
+import { z } from 'zod';
 
-export interface ExampleType {
-  id: string;
-  name: string;
-}
-
-export type TokenMetaUpdate = {
-  type: "tokenMeta.update";
-  at: string;
-  payload: {
-    pairSymbol: string;
-    dex: "uniswap" | "sushiswap";
-    lpAddress: `0x${string}`;
-    reserves: { r0: string; r1: string; block: number };
-    price: string;
-    liquidityUSD?: string;
-    spread?: string;
-  };
-};
-
-export const tokenMetaUpdateSchema: z.ZodType<TokenMetaUpdate> = z.object({
-  type: z.literal("tokenMeta.update"),
-  at: z.string(),
-  payload: z.object({
-    pairSymbol: z.string(),
-    dex: z.enum(["uniswap", "sushiswap"]),
-    lpAddress: z.string().regex(/^0x[0-9a-fA-F]+$/) as z.ZodType<`0x${string}`>,
-    reserves: z.object({
-      r0: z.string(),
-      r1: z.string(),
-      block: z.number(),
-    }),
-    price: z.string(),
-    liquidityUSD: z.string().optional(),
-    spread: z.string().optional(),
-  }),
+export const reservesZ = z.object({
+  r0: z.string(),
+  r1: z.string(),
+  block: z.number().int().nonnegative(),
 });
+
+export const tokenMetaPayloadZ = z.object({
+  pairSymbol: z.string(),
+  dex: z.enum(['uniswap', 'sushiswap']),
+  lpAddress: z.string().regex(/^0x[a-fA-F0-9]{40}$/),
+  reserves: reservesZ,
+  price: z.string(),
+  liquidityUSD: z.string().optional(),
+  spread: z.string().optional(),
+});
+
+export const tokenMetaUpdateZ = z.object({
+  type: z.literal('tokenMeta.update'),
+  at: z.string(),
+  payload: tokenMetaPayloadZ,
+});
+
+export type TokenMetaUpdate = z.infer<typeof tokenMetaUpdateZ>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
 
   backend:
     dependencies:
+      '@t-op-arb-bot/types':
+        specifier: workspace:*
+        version: link:../packages/types
       dotenv:
         specifier: ^17.2.1
         version: 17.2.1
@@ -54,6 +57,9 @@ importers:
 
   frontend:
     dependencies:
+      '@t-op-arb-bot/types':
+        specifier: workspace:*
+        version: link:../packages/types
       react:
         specifier: ^18.3.1
         version: 18.3.1


### PR DESCRIPTION
## Summary
- replace ws server with validated, snapshot-based implementation
- share TokenMeta schema via @t-op-arb-bot/types
- expose start/broadcast API and wire up in backend

## Testing
- `pnpm test` *(fails: backend test: No test files found)*
- `pnpm lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689976c13560832a818f8ed6d6cb343d