### PR TITLE
feat(backend): wire sync listener and bootstrap pairs

### DIFF
--- a/backend/src/bootstrap/pairs.ts
+++ b/backend/src/bootstrap/pairs.ts
@@ -1,0 +1,27 @@
+// backend/src/bootstrap/pairs.ts
+import { logger } from '../utils/logger';
+
+export type MatchedLP = {
+  pairSymbol: string; // e.g., "WETH/USDC"
+  uniswapLP: `0x${string}`;
+  sushiswapLP: `0x${string}`;
+  token0: { address: `0x${string}`; symbol: string; decimals: number };
+  token1: { address: `0x${string}`; symbol: string; decimals: number };
+};
+
+export async function bootstrapMatchedLPs(): Promise<MatchedLP[]> {
+  // TODO: Replace with real collectors:
+  //  - load UniswapV2 pairs (WETH/USDC, …)
+  //  - load SushiSwapV2 pairs
+  //  - match by canonical token ordering (address asc) or by symbol map
+  //  - return only pairs present on BOTH DEXes
+
+  // Example stub to keep the pipeline runnable:
+  const stub: MatchedLP[] = [];
+  if (stub.length === 0) {
+    logger.warn(
+      'bootstrapMatchedLPs produced 0 pairs (stub). Wire real DEX collectors here.'
+    );
+  }
+  return stub;
+}

--- a/backend/src/core/syncListener.ts
+++ b/backend/src/core/syncListener.ts
@@ -1,163 +1,79 @@
-import { Contract, formatUnits, WebSocketProvider } from 'ethers';
-import { logDexEvent, logError } from '../utils/logger';
+import { Contract, WebSocketProvider, formatUnits } from 'ethers';
+import type { MatchedLP } from '../bootstrap/pairs';
+import { env } from '../config/env';
+import { logger } from '../utils/logger';
 
-/**
- * Minimal ABI required for listening to Sync events and fetching reserves.
- */
 const PAIR_ABI = [
   'event Sync(uint112 reserve0, uint112 reserve1)',
   'function getReserves() view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast)',
-  'function token0() view returns (address)',
-  'function token1() view returns (address)'
 ] as const;
 
-const ERC20_ABI = [
-  'function decimals() view returns (uint8)'
-] as const;
-
-export interface MatchedLP {
-  /** Symbol of the trading pair e.g. WETH/USDC */
+export type SyncUpdate = {
   pairSymbol: string;
-  /** UniswapV2 pair address */
-  uniPair: string;
-  /** SushiSwap pair address */
-  sushiPair: string;
-}
+  dex: 'uniswap' | 'sushiswap';
+  lpAddress: `0x${string}`;
+  reserves: { r0: string; r1: string };
+  blockNumber: number;
+  price: string; // normalized decimal string
+  liquidityUSD?: string; // optional
+  spreadBps?: string; // optional bps string
+};
 
-export interface SpreadBroadcast {
-  type: 'spread.update';
-  payload: {
-    pairSymbol: string;
-    midPrice: number;
-    spreadBps: number;
-    reserves: {
-      uni: { reserve0: string; reserve1: string };
-      sushi: { reserve0: string; reserve1: string };
-    };
-    liquidityBps: number;
-    timestamp: number;
-  };
-}
+export async function startSyncListener(
+  matched: MatchedLP[],
+  onUpdate: (u: SyncUpdate) => void
+): Promise<void> {
+  const provider = new WebSocketProvider(env.RPC_WSS_URL);
 
-export type BroadcastFn = (msg: SpreadBroadcast) => void;
+  for (const pair of matched) {
+    const uni = new Contract(pair.uniswapLP, PAIR_ABI, provider);
+    const sushi = new Contract(pair.sushiswapLP, PAIR_ABI, provider);
 
-interface PairContracts {
-  uni: Contract;
-  sushi: Contract;
-  decimals0: number;
-  decimals1: number;
-}
-
-/**
- * Starts listeners for Sync events on matched LP pairs and broadcasts
- * mid-price spreads when thresholds are crossed or liquidity changes.
- */
-export function startSyncListener(
-  pairs: MatchedLP[],
-  provider: WebSocketProvider,
-  broadcast: BroadcastFn,
-  opts: { spreadThresholdBps?: number; liquidityThresholdBps?: number } = {}
-): void {
-  const spreadThreshold = opts.spreadThresholdBps ?? 1; // default 1 bps
-  const liquidityThreshold = opts.liquidityThresholdBps ?? 100; // default 100 bps = 1%
-
-  const contracts = new Map<string, PairContracts>();
-  const pending = new Map<string, true>();
-  const lastLiquidity = new Map<string, number>();
-  let processing = false;
-
-  async function loadDecimals(pair: Contract): Promise<[number, number]> {
-    const [t0, t1] = await Promise.all([pair.token0(), pair.token1()]);
-    const token0 = new Contract(t0, ERC20_ABI, provider);
-    const token1 = new Contract(t1, ERC20_ABI, provider);
-    const [d0, d1] = await Promise.all([token0.decimals(), token1.decimals()]);
-    return [Number(d0), Number(d1)];
-  }
-
-  function queue(symbol: string): void {
-    pending.set(symbol, true);
-    if (!processing) void process();
-  }
-
-  async function process(): Promise<void> {
-    processing = true;
-    while (pending.size > 0) {
-      const symbol = pending.keys().next().value as string;
-      pending.delete(symbol);
-      const c = contracts.get(symbol);
-      if (!c) continue;
-      try {
-        const [[ru0, ru1], [rs0, rs1]] = await Promise.all([
-          c.uni.getReserves(),
-          c.sushi.getReserves(),
-        ]);
-
-        const ru0n = Number(formatUnits(ru0, c.decimals0));
-        const ru1n = Number(formatUnits(ru1, c.decimals1));
-        const rs0n = Number(formatUnits(rs0, c.decimals0));
-        const rs1n = Number(formatUnits(rs1, c.decimals1));
-
-        const priceUni = ru1n / ru0n;
-        const priceSushi = rs1n / rs0n;
-        const mid = (priceUni + priceSushi) / 2;
-        const spread = Math.abs(priceUni - priceSushi) / mid * 10_000;
-
-        const liqUni = ru0n * ru1n;
-        const liqSushi = rs0n * rs1n;
-        const totalLiquidity = liqUni + liqSushi;
-        const prevLiq = lastLiquidity.get(symbol) ?? totalLiquidity;
-        const liquidityBps = Math.abs((totalLiquidity - prevLiq) / prevLiq) * 10_000;
-        lastLiquidity.set(symbol, totalLiquidity);
-
-        if (spread >= spreadThreshold || liquidityBps >= liquidityThreshold) {
-          broadcast({
-            type: 'spread.update',
-            payload: {
-              pairSymbol: symbol,
-              midPrice: mid,
-              spreadBps: spread,
-              reserves: {
-                uni: { reserve0: ru0.toString(), reserve1: ru1.toString() },
-                sushi: { reserve0: rs0.toString(), reserve1: rs1.toString() },
-              },
-              liquidityBps,
-              timestamp: Date.now(),
-            },
-          });
-        }
-      } catch (err) {
-        logError('processSync', err);
-      }
-    }
-    processing = false;
-  }
-
-  for (const p of pairs) {
-    const uni = new Contract(p.uniPair, PAIR_ABI, provider);
-    const sushi = new Contract(p.sushiPair, PAIR_ABI, provider);
-    let decimals0 = 18;
-    let decimals1 = 18;
-    loadDecimals(uni)
-      .then(([d0, d1]) => {
-        decimals0 = d0;
-        decimals1 = d1;
-      })
-      .catch((err) => logError('loadDecimals', err));
-
-    contracts.set(p.pairSymbol, { uni, sushi, decimals0, decimals1 });
-
-    const handler = (dex: string) => (
+    const handler = async (
       _r0: bigint,
       _r1: bigint,
-      event: { blockNumber: number },
+      event: { blockNumber: number }
     ) => {
-      logDexEvent(dex, p.pairSymbol, event.blockNumber);
-      queue(p.pairSymbol);
+      try {
+        const [[ru0, ru1], [rs0, rs1]] = await Promise.all([
+          uni.getReserves(),
+          sushi.getReserves(),
+        ]);
+
+        const ru0n = formatUnits(ru0, pair.token0.decimals);
+        const ru1n = formatUnits(ru1, pair.token1.decimals);
+        const rs0n = formatUnits(rs0, pair.token0.decimals);
+        const rs1n = formatUnits(rs1, pair.token1.decimals);
+
+        const priceUni = Number(ru1n) / Number(ru0n);
+        const priceSushi = Number(rs1n) / Number(rs0n);
+        const mid = (priceUni + priceSushi) / 2;
+        const spread = mid === 0 ? 0 : (Math.abs(priceUni - priceSushi) / mid) * 10_000;
+
+        onUpdate({
+          pairSymbol: pair.pairSymbol,
+          dex: 'uniswap',
+          lpAddress: pair.uniswapLP,
+          reserves: { r0: ru0n, r1: ru1n },
+          blockNumber: event.blockNumber,
+          price: priceUni.toString(),
+          spreadBps: spread.toString(),
+        });
+        onUpdate({
+          pairSymbol: pair.pairSymbol,
+          dex: 'sushiswap',
+          lpAddress: pair.sushiswapLP,
+          reserves: { r0: rs0n, r1: rs1n },
+          blockNumber: event.blockNumber,
+          price: priceSushi.toString(),
+          spreadBps: spread.toString(),
+        });
+      } catch (err) {
+        logger.error({ err, pair: pair.pairSymbol }, 'syncListener error');
+      }
     };
 
-    uni.on('Sync', handler('Uniswap'));
-    sushi.on('Sync', handler('SushiSwap'));
+    uni.on('Sync', handler);
+    sushi.on('Sync', handler);
   }
 }
-
-export default startSyncListener;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,7 +1,73 @@
-import './monitoring/metrics';
-import './server/http';
+// backend/src/index.ts
+import 'dotenv/config';
+import { env } from './config/env';
 import { logger } from './utils/logger';
-import { startWsServer } from './server/wsServer';
 
-startWsServer();
-logger.info('Backend running');
+import { startHttpServer, setHealthProbe } from './server/http';
+import { startMetricsServer } from './monitoring/metrics';
+import {
+  startWsServer,
+  upsertSnapshot,
+  broadcastUpdate,
+} from './server/wsServer';
+
+import { bootstrapMatchedLPs } from './bootstrap/pairs';
+import { startSyncListener, type SyncUpdate } from './core/syncListener';
+
+async function main() {
+  logger.info({ env: { chainId: env.CHAIN_ID } }, 'Boot start');
+
+  // 1) Metrics + HTTP + WS
+  startMetricsServer(env.METRICS_PORT);
+  startHttpServer(); // exposes /healthz, /version, /pairs
+  startWsServer(env.WS_PORT);
+
+  // 2) Collect & match LPs (Uniswap/Sushi) → canonical matched list
+  logger.info('Collecting & matching LPs…');
+  const matchedLPs = await bootstrapMatchedLPs();
+  logger.info({ count: matchedLPs.length }, 'Matched LPs ready');
+
+  // 3) Wire health probe to latest block observed by SyncListener
+  let latestBlockObserved = 0;
+  setHealthProbe(() => ({ block: latestBlockObserved }));
+
+  // 4) Start realtime Sync listener → normalize → WS snapshot + broadcast
+  logger.info('Starting SyncListener…');
+  await startSyncListener(matchedLPs, (update: SyncUpdate) => {
+    // Map SyncUpdate → TokenMetaUpdate['payload']
+    // NOTE: `syncListener` should already return normalized price/spread as strings.
+    const payload = {
+      pairSymbol: update.pairSymbol,
+      dex: update.dex, // 'uniswap' | 'sushiswap'
+      lpAddress: update.lpAddress,
+      reserves: {
+        r0: update.reserves.r0,
+        r1: update.reserves.r1,
+        block: update.blockNumber,
+      },
+      price: update.price,
+      liquidityUSD: update.liquidityUSD,
+      spread: update.spreadBps,
+    } as const;
+
+    // keep snapshot current for new WS clients
+    upsertSnapshot(payload);
+    // broadcast to all connected clients
+    broadcastUpdate(payload);
+
+    // update health
+    if (update.blockNumber > latestBlockObserved) {
+      latestBlockObserved = update.blockNumber;
+    }
+  });
+
+  logger.info(
+    { wsPort: env.WS_PORT, metricsPort: env.METRICS_PORT },
+    'Backend running'
+  );
+}
+
+main().catch((err) => {
+  logger.fatal({ err }, 'Fatal boot error');
+  process.exit(1);
+});

--- a/backend/src/server/http.ts
+++ b/backend/src/server/http.ts
@@ -1,46 +1,48 @@
 import http from 'node:http';
-
 import { env } from '../config/env';
 import { logger } from '../utils/logger';
 
 const commit = process.env.COMMIT ?? 'unknown';
 const builtAt = process.env.BUILT_AT ?? new Date().toISOString();
 
-let latestBlock = 0;
+let healthProbe: () => { block: number } = () => ({ block: 0 });
 let trackedPairs: unknown[] = [];
 
-export function setLatestBlock(block: number): void {
-  latestBlock = block;
+export function setHealthProbe(fn: () => { block: number }): void {
+  healthProbe = fn;
 }
 
 export function setTrackedPairs(pairs: unknown[]): void {
   trackedPairs = pairs;
 }
 
-const server = http.createServer((req, res) => {
-  if (req.method === 'GET' && req.url === '/healthz') {
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ status: 'ok', block: latestBlock }));
-    return;
-  }
+export function startHttpServer(port = env.HTTP_PORT) {
+  const server = http.createServer((req, res) => {
+    if (req.method === 'GET' && req.url === '/healthz') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok', ...healthProbe() }));
+      return;
+    }
 
-  if (req.method === 'GET' && req.url === '/version') {
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ commit, builtAt }));
-    return;
-  }
+    if (req.method === 'GET' && req.url === '/version') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ commit, builtAt }));
+      return;
+    }
 
-  if (req.method === 'GET' && req.url === '/pairs') {
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify(trackedPairs));
-    return;
-  }
+    if (req.method === 'GET' && req.url === '/pairs') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(trackedPairs));
+      return;
+    }
 
-  res.writeHead(404);
-  res.end('Not Found');
-});
+    res.writeHead(404);
+    res.end('Not Found');
+  });
 
-server.listen(env.HTTP_PORT, '0.0.0.0', () => {
-  logger.info(`HTTP server listening on port ${env.HTTP_PORT}`);
-});
+  server.listen(port, '0.0.0.0', () => {
+    logger.info(`HTTP server listening on port ${port}`);
+  });
 
+  return server;
+}


### PR DESCRIPTION
## Summary
- replace backend entrypoint to wire metrics, http, ws and sync listener
- add bootstrap adapter for matched LP pairs
- refactor http and metrics servers to expose start functions
- align sync listener with new update callback interface

## Testing
- `pnpm --filter backend lint` *(fails: ESLint couldn't find an eslint.config file)*
- `pnpm --filter backend test --run` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689978e7594c832ab21a88b656a31902