### PR TITLE
Handle LP supply updates

### DIFF
--- a/backend/src/core/syncListener.ts
+++ b/backend/src/core/syncListener.ts
@@ -3,9 +3,15 @@ import type { MatchedLP } from '../bootstrap/pairs';
 import { env } from '../config/env';
 import { logger } from '../utils/logger';
 
+const SUPPLY_REFRESH_EVERY = 50;
+
 const PAIR_ABI = [
   'event Sync(uint112 reserve0, uint112 reserve1)',
+  'event Transfer(address indexed from, address indexed to, uint256 value)',
+  'event Mint(address indexed sender, uint256 amount0, uint256 amount1)',
+  'event Burn(address indexed sender, uint256 amount0, uint256 amount1, address indexed to)',
   'function getReserves() view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast)',
+  'function totalSupply() view returns (uint256)',
 ] as const;
 
 export type SyncUpdate = {
@@ -19,15 +25,64 @@ export type SyncUpdate = {
   spreadBps?: string;     // optional bps string
 };
 
+export type LPUpdate = {
+  pairSymbol: string;
+  dex: 'uniswap' | 'sushiswap';
+  lpAddress: `0x${string}`;
+  totalSupply: string;
+  blockNumber: number;
+};
+
 export async function startSyncListener(
   matched: MatchedLP[],
-  onUpdate: (u: SyncUpdate) => void
+  onUpdate: (u: SyncUpdate) => void,
+  onLPUpdate: (u: LPUpdate) => void = () => {}
 ): Promise<void> {
   const provider = new WebSocketProvider(env.RPC_WSS_URL);
 
   for (const pair of matched) {
     const uni = new Contract(pair.uniswapLP, PAIR_ABI, provider);
     const sushi = new Contract(pair.sushiswapLP, PAIR_ABI, provider);
+
+    let uniSupply: bigint | null = null;
+    let sushiSupply: bigint | null = null;
+    let uniSyncs = 0;
+    let sushiSyncs = 0;
+
+    const emitSupply = async (
+      dex: 'uniswap' | 'sushiswap',
+      contract: Contract,
+      blockNumber: number
+    ) => {
+      try {
+        const total = await contract.totalSupply();
+        const cached = dex === 'uniswap' ? uniSupply : sushiSupply;
+        if (cached !== null && total === cached) return;
+        if (dex === 'uniswap') {
+          uniSupply = total;
+        } else {
+          sushiSupply = total;
+        }
+        onLPUpdate({
+          pairSymbol: pair.pairSymbol,
+          dex,
+          lpAddress: dex === 'uniswap' ? pair.uniswapLP : pair.sushiswapLP,
+          totalSupply: formatUnits(total, 18),
+          blockNumber,
+        });
+      } catch (err) {
+        logger.error({ err, pair: pair.pairSymbol, dex }, 'totalSupply error');
+      }
+    };
+
+    const supplyEventHandler = (
+      dex: 'uniswap' | 'sushiswap',
+      contract: Contract
+    ) => async (...args: unknown[]) => {
+      const event = args[args.length - 1] as EventLog;
+      const blockNumber = Number(event.blockNumber ?? 0);
+      await emitSupply(dex, contract, blockNumber);
+    };
 
     const handler = async (_r0: bigint, _r1: bigint, event: EventLog) => {
       try {
@@ -84,6 +139,15 @@ export async function startSyncListener(
           price: priceSushi.toString(),
           spreadBps: spreadBps.toString(),
         });
+
+        if (++uniSyncs >= SUPPLY_REFRESH_EVERY) {
+          uniSyncs = 0;
+          await emitSupply('uniswap', uni, blockNumber);
+        }
+        if (++sushiSyncs >= SUPPLY_REFRESH_EVERY) {
+          sushiSyncs = 0;
+          await emitSupply('sushiswap', sushi, blockNumber);
+        }
       } catch (err) {
         logger.error({ err, pair: pair.pairSymbol }, 'syncListener error');
       }
@@ -92,5 +156,11 @@ export async function startSyncListener(
     // Subscribe
     uni.on('Sync', handler);
     sushi.on('Sync', handler);
+    uni.on('Transfer', supplyEventHandler('uniswap', uni));
+    uni.on('Mint', supplyEventHandler('uniswap', uni));
+    uni.on('Burn', supplyEventHandler('uniswap', uni));
+    sushi.on('Transfer', supplyEventHandler('sushiswap', sushi));
+    sushi.on('Mint', supplyEventHandler('sushiswap', sushi));
+    sushi.on('Burn', supplyEventHandler('sushiswap', sushi));
   }
 }


### PR DESCRIPTION
## Summary
- listen for Transfer, Mint and Burn events from LP contracts
- compute and emit totalSupply updates with caching and periodic refresh

## Testing
- `pnpm --filter backend test -- --run --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6899c72e7754832a9e179139f23c5cf7