### PR TITLE
test: cover simulateUnknownTx in backend

### DIFF
--- a/backend/src/simulateUnknownTx.test.ts
+++ b/backend/src/simulateUnknownTx.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe('simulateUnknownTx', () => {
+  it('returns parsed trace on success', async () => {
+    const debugTraceMock = vi.fn().mockResolvedValue({
+      input: '0x12345678abcdef',
+      calls: [{ input: '0x12345678abcdef' }]
+    });
+    vi.doMock('../../src/clients/viemClient', () => ({
+      viemClient: { debug_traceTransaction: debugTraceMock }
+    }));
+    const decodeSelectorMock = vi.fn().mockReturnValue({ method: 'foo', args: ['bar'] });
+    vi.doMock('../../src/utils/decodeSelector', () => ({ decodeSelector: decodeSelectorMock }));
+    const decodeRawArgsHexMock = vi.fn().mockReturnValue(['arg']);
+    vi.doMock('../../src/utils/decodeRawArgsHex', () => ({ decodeRawArgsHex: decodeRawArgsHexMock }));
+    const fetchAbiSignatureMock = vi.fn().mockResolvedValue(null);
+    vi.doMock('../../src/utils/fetchAbiSignature', () => ({ fetchAbiSignature: fetchAbiSignatureMock }));
+    const parsedTrace = { contract: '0x1', from: '0x2', method: 'foo', args: ['bar'], ethTransferred: '0', gasUsed: '0', input: '0x12345678abcdef', depth: 0, children: [] };
+    const parseTraceMock = vi.fn().mockReturnValue(parsedTrace);
+    vi.doMock('../../src/utils/traceParsers', () => ({ parseTrace: parseTraceMock }));
+
+    const { simulateUnknownTx } = await import('../../src/abie/simulation/simulateUnknownTx');
+    const result = await simulateUnknownTx({ txHash: '0xabc' });
+
+    expect(debugTraceMock).toHaveBeenCalled();
+    expect(decodeSelectorMock).toHaveBeenCalled();
+    expect(parseTraceMock).toHaveBeenCalledWith({ input: '0x12345678abcdef', calls: [{ input: '0x12345678abcdef' }] }, { method: 'foo', args: ['bar'] });
+    expect(result).toEqual(parsedTrace);
+  });
+
+  it('returns null and logs error on failure', async () => {
+    const debugTraceMock = vi.fn().mockRejectedValue(new Error('boom'));
+    vi.doMock('../../src/clients/viemClient', () => ({
+      viemClient: { debug_traceTransaction: debugTraceMock }
+    }));
+    vi.doMock('../../src/utils/decodeSelector', () => ({ decodeSelector: vi.fn() }));
+    vi.doMock('../../src/utils/decodeRawArgsHex', () => ({ decodeRawArgsHex: vi.fn() }));
+    vi.doMock('../../src/utils/fetchAbiSignature', () => ({ fetchAbiSignature: vi.fn() }));
+    vi.doMock('../../src/utils/traceParsers', () => ({ parseTrace: vi.fn() }));
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { simulateUnknownTx } = await import('../../src/abie/simulation/simulateUnknownTx');
+    const result = await simulateUnknownTx({ txHash: '0xabc' });
+
+    expect(result).toBeNull();
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/src/abie/simulation/simulateUnknownTx.ts
+++ b/src/abie/simulation/simulateUnknownTx.ts
@@ -1,11 +1,11 @@
 // src/abie/simulation/simulateUnknownTx.ts
 
-import { viemClient } from "@/clients/viemClient";
-import { decodeSelector } from "@/utils/decodeSelector";
-import { decodeRawArgsHex } from "@/utils/decodeRawArgsHex";
-import { fetchAbiSignature } from "@/utils/fetchAbiSignature";
-import { TraceResult } from "@/types/traceTypes";
-import { parseTrace } from "@/utils/traceParsers";
+import { viemClient } from "../../clients/viemClient";
+import { decodeSelector } from "../../utils/decodeSelector";
+import { decodeRawArgsHex } from "../../utils/decodeRawArgsHex";
+import { fetchAbiSignature } from "../../utils/fetchAbiSignature";
+import { TraceResult } from "../../types/traceTypes";
+import { parseTrace } from "../../utils/traceParsers";
 
 interface SimulationInput {
   txHash: string;

--- a/src/clients/viemClient.ts
+++ b/src/clients/viemClient.ts
@@ -1,0 +1,5 @@
+export const viemClient = {
+  async debug_traceTransaction(_: any) {
+    return {} as any;
+  }
+};

--- a/src/core/test.ts
+++ b/src/core/test.ts
@@ -1,4 +1,0 @@
-it("should simulate unknown tx and return parsed trace", async () => {
-  const result = await simulateUnknownTx({ txHash: "0x..." });
-  expect(result).toBeDefined();
-});

--- a/src/utils/decodeRawArgsHex.ts
+++ b/src/utils/decodeRawArgsHex.ts
@@ -1,0 +1,3 @@
+export function decodeRawArgsHex(rawArgs: string): any[] {
+  return [];
+}

--- a/src/utils/decodeSelector.ts
+++ b/src/utils/decodeSelector.ts
@@ -1,0 +1,3 @@
+export function decodeSelector(selector: string, callData: string, abi?: any): any {
+  return null;
+}

--- a/src/utils/fetchAbiSignature.ts
+++ b/src/utils/fetchAbiSignature.ts
@@ -1,0 +1,3 @@
+export async function fetchAbiSignature(selector: string): Promise<any> {
+  return null;
+}

--- a/src/utils/traceParsers.ts
+++ b/src/utils/traceParsers.ts
@@ -1,0 +1,3 @@
+export function parseTrace(trace: any, decoded?: any): any {
+  return {};
+}


### PR DESCRIPTION
## Summary
- move simulateUnknownTx test into backend workspace
- add success and failure coverage for simulateUnknownTx
- switch simulateUnknownTx imports to relative paths and add minimal stubs

## Testing
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_689a3c8f6088832ab99b0ce5dae36e42