### PR TITLE
refactor: improve ws types

### DIFF
--- a/backend/src/server/wsServer.ts
+++ b/backend/src/server/wsServer.ts
@@ -18,6 +18,7 @@ export function startWsServer(port = env.WS_PORT) {
   if (wss) return controlSurface;
 
   wss = new WebSocketServer({ port });
+  globalThis.wss = wss;
   logger.info({ port }, 'WS server listening');
 
   wss.on('connection', handleConnection);
@@ -95,6 +96,7 @@ export function stopWsServer() {
 
   wss.close();
   wss = null;
+  globalThis.wss = undefined;
 }
 
 export const controlSurface = {

--- a/backend/src/types/global.d.ts
+++ b/backend/src/types/global.d.ts
@@ -1,0 +1,8 @@
+import { WebSocketServer } from 'ws';
+
+declare global {
+  var wss: WebSocketServer | undefined;
+}
+
+export {};
+

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -10,7 +10,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
-    "lib": ["ES2020"],
+    "lib": ["ES2022"],
     "types": ["node"],
     "composite": true,
     "baseUrl": ".",

--- a/packages/core/src/abie/broadcaster/abieBroadcaster.ts
+++ b/packages/core/src/abie/broadcaster/abieBroadcaster.ts
@@ -1,7 +1,7 @@
 // src/abie/broadcaster/abieBroadcaster.ts
 import { attachCommandRouter } from '../commands/commandRouter';
 
-import WebSocket, { WebSocketServer } from 'ws';
+import { WebSocket, WebSocketServer } from 'ws';
 
 /**
  * Creates and manages the ABIE WebSocket server for broadcasting real-time
@@ -21,7 +21,7 @@ console.log(`[ABIE] WebSocket broadcaster initialized on port ${PORT}`);
 export function broadcastABIEEvent(eventType: string, payload: any): void {
   const message = JSON.stringify({ type: eventType, data: payload });
 
-  wss.clients.forEach((client) => {
+  wss.clients.forEach((client: WebSocket) => {
     if (client.readyState === WebSocket.OPEN) {
       client.send(message);
     }

--- a/packages/core/src/abie/commands/commandHandlers.ts
+++ b/packages/core/src/abie/commands/commandHandlers.ts
@@ -1,6 +1,6 @@
 // src/abie/commands/commandHandlers.ts
 
-import WebSocket from 'ws';
+import { WebSocket, WebSocketServer } from 'ws';
 import { updateSlippageTolerance } from '../../config/arbitrageConfig';
 import { emitSystemLog } from '../broadcaster/broadcastHooks';
 
@@ -40,7 +40,7 @@ export const handleCommand = async (
  * Extend this as new controls become available.
  */
 const COMMAND_REGISTRY: Record<ABIECommand, CommandHandler> = {
-  adjust_slippage: (data, ws) => {
+  adjust_slippage: (data: any, ws: WebSocket) => {
     const { pairSymbol, newTolerance } = data;
     updateSlippageTolerance(pairSymbol, newTolerance);
 
@@ -50,7 +50,7 @@ const COMMAND_REGISTRY: Record<ABIECommand, CommandHandler> = {
     });
   },
 
-  enable_debug_mode: (_data, _ws) => {
+  enable_debug_mode: (_data: any, _ws: WebSocket) => {
     process.env.DEBUG_MODE = 'true';
     emitSystemLog({
       message: `ABIE debug mode enabled.`,
@@ -58,7 +58,7 @@ const COMMAND_REGISTRY: Record<ABIECommand, CommandHandler> = {
     });
   },
 
-  fetch_status: (_data, ws) => {
+  fetch_status: (_data: any, ws: WebSocket) => {
     const status = {
       uptime: process.uptime(),
       connectedClients: WebSocketServerSnapshot(),
@@ -73,7 +73,7 @@ const COMMAND_REGISTRY: Record<ABIECommand, CommandHandler> = {
     );
   },
 
-  clear_cache: (_data, _ws) => {
+  clear_cache: (_data: any, _ws: WebSocket) => {
     // Hook into cache-clearing utilities if needed
     emitSystemLog({
       message: 'Cache cleared manually.',

--- a/packages/core/src/abie/commands/commandRouter.ts
+++ b/packages/core/src/abie/commands/commandRouter.ts
@@ -1,6 +1,6 @@
 // src/abie/commands/commandRouter.ts
 
-import WebSocket from 'ws';
+import { WebSocket, WebSocketServer } from 'ws';
 import { handleCommand } from './commandHandlers';
 
 /**
@@ -10,7 +10,7 @@ import { handleCommand } from './commandHandlers';
  * @param ws - The WebSocket connection to bind command handling to
  */
 export function attachCommandRouter(ws: WebSocket): void {
-  ws.on('message', (data) => {
+  ws.on('message', (data: Buffer) => {
     try {
       const parsed = JSON.parse(data.toString());
 

--- a/packages/core/src/ws/broadcaster.ts
+++ b/packages/core/src/ws/broadcaster.ts
@@ -5,7 +5,7 @@
  * Useful for live dashboards, debug viewers, or real-time routing UIs.
  */
 
-import WebSocket, { WebSocketServer } from 'ws';
+import { WebSocket, WebSocketServer } from 'ws';
 import { TokenMeta } from '../core/metaConsolidator';
 
 const PORT = process.env.WS_PORT ? parseInt(process.env.WS_PORT) : 8081;


### PR DESCRIPTION
## Summary
- use named imports for `WebSocket` and `WebSocketServer`
- define global `wss` and expose it from the backend
- build with ES2022 libs to avoid DOM types

## Testing
- `pnpm -r build`


------
https://chatgpt.com/codex/tasks/task_e_689a5c41cdb0832a9e4b2550645f56cf