### PR TITLE
chore(core): configure vitest for empty test suites

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "eslint \"src/**/*.ts\"",
-    "test": "vitest"
+    "test": "vitest run --passWithNoTests"
   },
   "files": ["dist"],
   "exports": {

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    passWithNoTests: true,
+    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+    exclude: ['**/node_modules/**', '**/dist/**'],
+  },
+});


### PR DESCRIPTION
## Summary
- run `vitest` in core with `--passWithNoTests`
- add `vitest.config.mts` for core to allow passing without tests and to define include/exclude patterns

## Testing
- `pnpm --filter @blazing/core test`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_689a69c95af8832a83e734d920e9a19d