### PR TITLE
feat: support addPair or ingest in store

### DIFF
--- a/frontend/src/components/LivePairsTable.test.tsx
+++ b/frontend/src/components/LivePairsTable.test.tsx
@@ -20,8 +20,10 @@ vi.mock('../useArbStore', () => {
       at: '2024-01-01T00:00:00Z',
     },
   ];
+  const addPair = vi.fn();
   return {
-    useArbStore: (selector: any) => selector({ pairs, status: 'connected' }),
+    useArbStore: (selector: any) =>
+      selector({ pairs, status: 'connected', addPair, ingest: addPair }),
   };
 });
 

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -3,7 +3,7 @@ import { tokenMetaUpdateZ } from '@t-op-arb-bot/types';
 import { useArbStore } from '../useArbStore';
 
 export function useWebSocket() {
-  const addPair = useArbStore((s) => s.addPair);
+  const addPair = useArbStore((s) => s.addPair ?? s.ingest);
   const setStatus = useArbStore((s) => s.setStatus);
 
   const wsRef = useRef<WebSocket | null>(null);

--- a/frontend/src/useArbStore.test.ts
+++ b/frontend/src/useArbStore.test.ts
@@ -24,6 +24,18 @@ describe('useArbStore', () => {
     expect(state.pairs[0]).toEqual(samplePair);
   });
 
+  it('ingest upserts rowsByKey without duplicating order', () => {
+    const ingest =
+      useArbStore.getState().ingest ?? useArbStore.getState().addPair;
+    ingest(samplePair);
+    ingest({ ...samplePair, price: '101' });
+    const state = useArbStore.getState();
+    const key = `${samplePair.pairSymbol}:${samplePair.dex}`;
+    expect(Object.keys(state.rowsByKey)).toEqual([key]);
+    expect(state.rowsByKey[key].price).toBe('101');
+    expect(state.order).toEqual([key]);
+  });
+
   it('setStatus updates status', () => {
     useArbStore.getState().setStatus('connected');
     expect(useArbStore.getState().status).toBe('connected');


### PR DESCRIPTION
## Summary
- allow WebSocket hook to use either `addPair` or legacy `ingest` action
- expand store tests and include action alias in LivePairsTable tests

## Testing
- `pnpm --filter frontend test`

------
https://chatgpt.com/codex/tasks/task_e_689a700f80ec832a84d056459a6e64dc