### PR TITLE
feat: guard LivePairsTable against invalid pair data

### DIFF
--- a/frontend/src/components/LivePairsTable.tsx
+++ b/frontend/src/components/LivePairsTable.tsx
@@ -18,10 +18,12 @@ export default function LivePairsTable() {
   );
   const [minLiquidity, setMinLiquidity] = useState(0);
   const [minSpreadBps, setMinSpreadBps] = useState(0);
+  const pairList = Array.isArray(pairs) ? pairs : [];
+  if (!Array.isArray(pairs)) console.warn('LivePairsTable: pairs is not an array', pairs);
+
   const rows = useMemo<Row[]>(() => {
-    if (!Array.isArray(pairs)) return [];
     const map = new Map<string, Row>();
-    for (const p of pairs) {
+    for (const p of pairList) {
       const existing = map.get(p.pairSymbol) ?? { pair: p.pairSymbol };
       const price = Number(p.price);
       const liquidity = p.liquidityUSD ? Number(p.liquidityUSD) : undefined;
@@ -45,7 +47,7 @@ export default function LivePairsTable() {
           (r.liquidityUSD ?? 0) >= minLiquidity &&
           (r.spreadBps ?? -Infinity) >= minSpreadBps,
       );
-  }, [pairs, minLiquidity, minSpreadBps]);
+  }, [pairList, minLiquidity, minSpreadBps]);
 
   const format = (n?: number) => (n != null ? n.toFixed(2) : '-');
 


### PR DESCRIPTION
## Summary
- guard against non-array `pairs` in LivePairsTable and warn when invalid
- iterate over validated pair list in memoized row calculations

## Testing
- `pnpm --filter frontend test`


------
https://chatgpt.com/codex/tasks/task_e_689a725c39d0832aa05da0be1edfb9fc