### PR TITLE
Add simulation modal to LivePairsTable

### DIFF
--- a/frontend/src/components/LivePairsTable.test.tsx
+++ b/frontend/src/components/LivePairsTable.test.tsx
@@ -3,6 +3,7 @@ import LivePairsTable from './LivePairsTable';
 import React from 'react';
 import { vi, describe, it, expect } from 'vitest';
 
+let status = 'connected';
 vi.mock('../useArbStore', () => {
   const pairs = [
     {
@@ -23,12 +24,13 @@ vi.mock('../useArbStore', () => {
   const addPair = vi.fn();
   return {
     useArbStore: (selector: any) =>
-      selector({ pairs, status: 'connected', addPair, ingest: addPair }),
+      selector({ pairs, status, addPair, ingest: addPair }),
   };
 });
 
 describe('LivePairsTable', () => {
   it('renders rows and filters by liquidity', () => {
+    status = 'connected';
     render(<LivePairsTable />);
     expect(screen.getByText('connected')).toBeInTheDocument();
     expect(screen.getByText('ETH/USDC')).toBeInTheDocument();
@@ -36,5 +38,12 @@ describe('LivePairsTable', () => {
     const liquidityInput = screen.getByLabelText('Min Liquidity');
     fireEvent.change(liquidityInput, { target: { value: '300' } });
     expect(screen.queryByText('ETH/USDC')).not.toBeInTheDocument();
+  });
+
+  it('disables simulate button when disconnected', () => {
+    status = 'disconnected';
+    render(<LivePairsTable />);
+    const button = screen.getByText('Simulate') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
   });
 });

--- a/frontend/src/components/LivePairsTable.tsx
+++ b/frontend/src/components/LivePairsTable.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { useArbStore } from '../useArbStore';
 import { shallow } from 'zustand/shallow';
+import SimulateModal from './SimulateModal';
 
 interface Row {
   pair: string;
@@ -18,6 +19,7 @@ export default function LivePairsTable() {
   );
   const [minLiquidity, setMinLiquidity] = useState(0);
   const [minSpreadBps, setMinSpreadBps] = useState(0);
+  const [simulatePair, setSimulatePair] = useState<Row | null>(null);
   const pairList = Array.isArray(pairs) ? pairs : [];
   if (!Array.isArray(pairs)) console.warn('LivePairsTable: pairs is not an array', pairs);
 
@@ -94,6 +96,7 @@ export default function LivePairsTable() {
             <th>Spread (bps)</th>
             <th>Liquidity USD</th>
             <th>Last Update</th>
+            <th>Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -118,10 +121,21 @@ export default function LivePairsTable() {
               <td>
                 {r.lastUpdate ? new Date(r.lastUpdate).toLocaleTimeString() : '-'}
               </td>
+              <td>
+                <button
+                  disabled={status !== 'connected'}
+                  onClick={() => setSimulatePair(r)}
+                >
+                  Simulate
+                </button>
+              </td>
             </tr>
           ))}
         </tbody>
       </table>
+      {simulatePair && (
+        <SimulateModal pair={simulatePair} onClose={() => setSimulatePair(null)} />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/SimulateModal.tsx
+++ b/frontend/src/components/SimulateModal.tsx
@@ -1,0 +1,119 @@
+import React, { useState } from 'react';
+
+interface PairInfo {
+  pair: string;
+  uniswapPrice?: number;
+  sushiswapPrice?: number;
+}
+
+interface SimulationResult {
+  gas: number;
+  flashFee: number;
+  netProfit: number;
+}
+
+interface Props {
+  pair: PairInfo | null;
+  onClose: () => void;
+}
+
+const overlayStyle: React.CSSProperties = {
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  backgroundColor: 'rgba(0,0,0,0.5)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+};
+
+const modalStyle: React.CSSProperties = {
+  background: 'white',
+  padding: '1rem',
+  borderRadius: '0.5rem',
+  minWidth: '300px',
+};
+
+export default function SimulateModal({ pair, onClose }: Props) {
+  const [amount, setAmount] = useState('');
+  const [slippageBps, setSlippageBps] = useState('0');
+  const [routerOrder, setRouterOrder] = useState<'uniToSushi' | 'sushiToUni'>('uniToSushi');
+  const [result, setResult] = useState<SimulationResult | null>(null);
+
+  if (!pair) return null;
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const res = await fetch('/simulate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          pair: pair.pair,
+          amount: Number(amount),
+          slippageBps: Number(slippageBps),
+          routerOrder,
+        }),
+      });
+      const data = await res.json();
+      setResult(data);
+    } catch (err) {
+      console.error('Simulation failed', err);
+    }
+  };
+
+  return (
+    <div style={overlayStyle}>
+      <div style={modalStyle}>
+        <h2>Simulate {pair.pair}</h2>
+        <form onSubmit={submit} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          <label>
+            Amount
+            <input
+              type="number"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              style={{ marginLeft: '0.25rem' }}
+            />
+          </label>
+          <label>
+            Slippage (bps)
+            <input
+              type="number"
+              value={slippageBps}
+              onChange={(e) => setSlippageBps(e.target.value)}
+              style={{ marginLeft: '0.25rem' }}
+            />
+          </label>
+          <label>
+            Router Order
+            <select
+              value={routerOrder}
+              onChange={(e) => setRouterOrder(e.target.value as any)}
+              style={{ marginLeft: '0.25rem' }}
+            >
+              <option value="uniToSushi">Uni → Sushi</option>
+              <option value="sushiToUni">Sushi → Uni</option>
+            </select>
+          </label>
+          <div style={{ marginTop: '1rem' }}>
+            <button type="submit">Simulate</button>
+            <button type="button" onClick={onClose} style={{ marginLeft: '0.5rem' }}>
+              Close
+            </button>
+          </div>
+        </form>
+        {result && (
+          <div style={{ marginTop: '1rem' }}>
+            <div>Gas: {result.gas}</div>
+            <div>Flash Fee: {result.flashFee}</div>
+            <div>Net Profit: {result.netProfit}</div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add modal for simulating trades with amount, slippage, and router order inputs
- wire LivePairsTable rows to open the modal and disable when wallet disconnected
- verify Simulate button disables when wallet status is disconnected

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689a8fa91038832a8b03a4aa7333595f