### PR TITLE
feat(server): add quote and simulation endpoints

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,8 @@
     "pino": "^9.8.0",
     "prom-client": "^15.1.3",
     "ws": "^8.18.3",
-    "zod": "^4.0.17"
+    "zod": "^4.0.17",
+    "viem": "^2.5.2"
   },
   "devDependencies": {
     "@types/node": "^24.2.1",

--- a/backend/src/server/http.ts
+++ b/backend/src/server/http.ts
@@ -1,4 +1,7 @@
 import http from 'node:http';
+import { createPublicClient, http as viemHttp } from 'viem';
+import { UNISWAP_ROUTER_ABI } from '@blazing/core/abi-cache/ROUTER/uniswapV2Router.js';
+import { SUSHISWAP_ROUTER_ABI } from '@blazing/core/abi-cache/ROUTER/sushiswapV2Router.js';
 import { env } from '../config/env.js';
 import { logger } from '../utils/logger.js';
 
@@ -7,6 +10,21 @@ const builtAt = process.env.BUILT_AT ?? new Date().toISOString();
 
 let healthProbe: () => { block: number } = () => ({ block: 0 });
 let trackedPairs: unknown[] = [];
+
+const UNISWAP_ROUTER_ADDRESS =
+  '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D' as const;
+const SUSHISWAP_ROUTER_ADDRESS =
+  '0xd9e1cE17f2641F24Ae83637ab66a2cca9C378B9F' as const;
+
+const publicClient = createPublicClient({
+  chain: {
+    id: env.CHAIN_ID,
+    name: 'chain',
+    nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+    rpcUrls: { default: { http: [env.RPC_HTTP_URL] } },
+  },
+  transport: viemHttp(env.RPC_HTTP_URL),
+});
 
 export function setHealthProbe(fn: () => { block: number }): void {
   healthProbe = fn;
@@ -17,7 +35,7 @@ export function setTrackedPairs(pairs: unknown[]): void {
 }
 
 export function startHttpServer(port = env.HTTP_PORT) {
-  const server = http.createServer((req, res) => {
+  const server = http.createServer(async (req, res) => {
     if (req.method === 'GET' && req.url === '/healthz') {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ status: 'ok', ...healthProbe() }));
@@ -33,6 +51,95 @@ export function startHttpServer(port = env.HTTP_PORT) {
     if (req.method === 'GET' && req.url === '/pairs') {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify(trackedPairs));
+      return;
+    }
+
+    if (req.method === 'GET' && req.url?.startsWith('/quote')) {
+      try {
+        const url = new URL(req.url, `http://${req.headers.host}`);
+        const tokenIn = url.searchParams.get('tokenIn') as `0x${string}` | null;
+        const tokenOut = url.searchParams.get('tokenOut') as `0x${string}` | null;
+        const amountInStr = url.searchParams.get('amountIn') ?? '0';
+        const blockTagStr = url.searchParams.get('blockTag');
+        if (!tokenIn || !tokenOut) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'tokenIn and tokenOut required' }));
+          return;
+        }
+        const amountIn = BigInt(amountInStr);
+        const blockNumber = blockTagStr ? BigInt(blockTagStr) : undefined;
+        const [uniAmounts, sushiAmounts] = await Promise.all([
+          publicClient.readContract({
+            address: UNISWAP_ROUTER_ADDRESS,
+            abi: UNISWAP_ROUTER_ABI,
+            functionName: 'getAmountsOut',
+            args: [amountIn, [tokenIn, tokenOut]],
+            ...(blockNumber ? { blockNumber } : {}),
+          }),
+          publicClient.readContract({
+            address: SUSHISWAP_ROUTER_ADDRESS,
+            abi: SUSHISWAP_ROUTER_ABI,
+            functionName: 'getAmountsOut',
+            args: [amountIn, [tokenIn, tokenOut]],
+            ...(blockNumber ? { blockNumber } : {}),
+          }),
+        ]);
+        const payload = {
+          uniswap: (uniAmounts as bigint[]).map((x) => x.toString()),
+          sushiswap: (sushiAmounts as bigint[]).map((x) => x.toString()),
+        };
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(payload));
+      } catch (err) {
+        logger.error({ err }, 'quote failed');
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'quote failed' }));
+      }
+      return;
+    }
+
+    if (req.method === 'POST' && req.url === '/simulate') {
+      let body = '';
+      req.on('data', (chunk) => {
+        body += chunk;
+      });
+      req.on('end', async () => {
+        try {
+          const { address, abi, functionName, args, blockTag, flashFee } =
+            JSON.parse(body);
+          const blockNumber = blockTag ? BigInt(blockTag) : undefined;
+          const sim = await publicClient.simulateContract({
+            address: address as `0x${string}`,
+            abi: abi as any,
+            functionName,
+            args: args as any,
+            ...(blockNumber ? { blockNumber } : {}),
+          } as any);
+          const gasUsed = (sim as any).gasUsed ?? (sim.result as any)?.gasUsed;
+          const result = sim.result as any;
+          const response = {
+            gasUsed: gasUsed != null ? gasUsed.toString() : undefined,
+            flashFee:
+              result?.flashFee != null
+                ? typeof result.flashFee === 'bigint'
+                  ? result.flashFee.toString()
+                  : result.flashFee
+                : flashFee ?? null,
+            amounts: Array.isArray(result?.amounts)
+              ? result.amounts.map((x: any) =>
+                  typeof x === 'bigint' ? x.toString() : x
+                )
+              : result,
+            logs: (sim as any).logs ?? [],
+          };
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(response));
+        } catch (err) {
+          logger.error({ err }, 'simulation failed');
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'simulation failed' }));
+        }
+      });
       return;
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
+      viem:
+        specifier: ^2.5.2
+        version: 2.33.3(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.0.17)
       ws:
         specifier: ^8.18.3
         version: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -3990,7 +3993,7 @@ snapshots:
     dependencies:
       '@ethereumjs/tx': 4.2.0
       '@metamask/superstruct': 3.2.1
-      '@noble/hashes': 1.3.2
+      '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@types/debug': 4.1.12
       debug: 4.4.1
@@ -4015,7 +4018,7 @@ snapshots:
     dependencies:
       '@ethereumjs/tx': 4.2.0
       '@metamask/superstruct': 3.2.1
-      '@noble/hashes': 1.3.2
+      '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@types/debug': 4.1.12
       debug: 4.4.1
@@ -4029,7 +4032,7 @@ snapshots:
     dependencies:
       '@ethereumjs/tx': 4.2.0
       '@metamask/superstruct': 3.2.1
-      '@noble/hashes': 1.3.2
+      '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@types/debug': 4.1.12
       debug: 4.4.1
@@ -4446,7 +4449,7 @@ snapshots:
 
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.2
+      '@noble/curves': 1.9.6
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
@@ -5277,6 +5280,11 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.2
       zod: 3.22.4
+
+  abitype@1.0.8(typescript@5.9.2)(zod@4.0.17):
+    optionalDependencies:
+      typescript: 5.9.2
+      zod: 4.0.17
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -6272,10 +6280,10 @@ snapshots:
   ox@0.6.7(typescript@5.9.2)(zod@3.22.4):
     dependencies:
       '@adraffy/ens-normalize': 1.10.1
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
+      '@noble/curves': 1.9.6
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
       abitype: 1.0.8(typescript@5.9.2)(zod@3.22.4)
       eventemitter3: 5.0.1
     optionalDependencies:
@@ -6301,11 +6309,26 @@ snapshots:
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.2
+      '@noble/curves': 1.9.6
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.0.8(typescript@5.9.2)(zod@3.22.4)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.8.6(typescript@5.9.2)(zod@4.0.17):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.0
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.6
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.0.8(typescript@5.9.2)(zod@4.0.17)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.2
@@ -6937,6 +6960,23 @@ snapshots:
       abitype: 1.0.8(typescript@5.9.2)(zod@3.22.4)
       isows: 1.0.7(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       ox: 0.8.6(typescript@5.9.2)(zod@3.22.4)
+      ws: 8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.33.3(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.0.17):
+    dependencies:
+      '@noble/curves': 1.9.2
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.0.8(typescript@5.9.2)(zod@4.0.17)
+      isows: 1.0.7(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      ox: 0.8.6(typescript@5.9.2)(zod@4.0.17)
       ws: 8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.2


### PR DESCRIPTION
## Summary
- add GET `/quote` endpoint that uses `getAmountsOut` from each DEX router
- support POST `/simulate` endpoint backed by `viem` contract simulation
- register router addresses and viem client for HTTP server
- include `viem` dependency for backend

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689a90e5de00832a8888b5d9986bdb56