### PR TITLE
feat: add opportunity TTL heap and endpoint

### DIFF
--- a/backend/src/core/opportunityStore.test.ts
+++ b/backend/src/core/opportunityStore.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import { OpportunityStore } from './opportunityStore.js';
+
+describe('OpportunityStore', () => {
+  it('evicts lowest scored entries when capacity exceeded', () => {
+    const store = new OpportunityStore({ ttlMs: 1000, cap: 2 });
+    store.upsert('A', 1, 1); // score=1
+    store.upsert('B', 2, 1); // score=2
+    store.upsert('C', 3, 1); // score=3 -> evicts A
+    const pairs = store.snapshot().map((e) => e.pairSymbol).sort();
+    expect(pairs).toEqual(['B', 'C']);
+  });
+
+  it('removes entries past TTL', () => {
+    vi.useFakeTimers();
+    const store = new OpportunityStore({ ttlMs: 1000, cap: 5 });
+    store.upsert('A', 1, 1);
+    expect(store.size()).toBe(1);
+    vi.advanceTimersByTime(1001);
+    store.prune();
+    expect(store.size()).toBe(0);
+    vi.useRealTimers();
+  });
+});

--- a/backend/src/core/opportunityStore.ts
+++ b/backend/src/core/opportunityStore.ts
@@ -1,0 +1,136 @@
+export interface Opportunity {
+  pairSymbol: string;
+  spreadBps: number;
+  minLiquidityUSD: number;
+  score: number;
+  expiresAt: number;
+}
+
+interface HeapNode extends Opportunity {
+  index: number;
+}
+
+export class OpportunityStore {
+  private heap: HeapNode[] = [];
+  private map = new Map<string, HeapNode>();
+  private readonly ttlMs: number;
+  private readonly cap: number;
+  private cleanupInterval: NodeJS.Timer | null = null;
+
+  constructor(opts: { ttlMs?: number; cap?: number } = {}) {
+    this.ttlMs = opts.ttlMs ?? 60_000;
+    this.cap = opts.cap ?? 100;
+    // periodic pruning to avoid stale entries if no activity
+    this.cleanupInterval = setInterval(() => this.prune(), this.ttlMs);
+    // don't keep Node process alive
+    (this.cleanupInterval as any).unref?.();
+  }
+
+  upsert(pairSymbol: string, spreadBps: number, minLiquidityUSD: number): void {
+    const score = spreadBps * minLiquidityUSD;
+    const now = Date.now();
+    const expiresAt = now + this.ttlMs;
+
+    const existing = this.map.get(pairSymbol);
+    if (existing) {
+      existing.spreadBps = spreadBps;
+      existing.minLiquidityUSD = minLiquidityUSD;
+      existing.score = score;
+      existing.expiresAt = expiresAt;
+      this.bubbleUp(existing.index);
+      this.bubbleDown(existing.index);
+      return;
+    }
+
+    const node: HeapNode = {
+      pairSymbol,
+      spreadBps,
+      minLiquidityUSD,
+      score,
+      expiresAt,
+      index: this.heap.length,
+    };
+    this.heap.push(node);
+    this.map.set(pairSymbol, node);
+    this.bubbleUp(node.index);
+
+    if (this.heap.length > this.cap) {
+      const removed = this.pop();
+      if (removed) this.map.delete(removed.pairSymbol);
+    }
+  }
+
+  size(): number {
+    this.prune();
+    return this.heap.length;
+  }
+
+  snapshot(): Opportunity[] {
+    this.prune();
+    return [...this.heap]
+      .sort((a, b) => b.score - a.score)
+      .map(({ index: _i, ...rest }) => rest);
+  }
+
+  clear(): void {
+    this.heap = [];
+    this.map.clear();
+  }
+
+  private pop(): HeapNode | null {
+    if (this.heap.length === 0) return null;
+    const root = this.heap[0];
+    const last = this.heap.pop()!;
+    if (this.heap.length > 0) {
+      this.heap[0] = last;
+      last.index = 0;
+      this.bubbleDown(0);
+    }
+    root.index = -1;
+    return root;
+  }
+
+  private bubbleUp(idx: number): void {
+    while (idx > 0) {
+      const parent = Math.floor((idx - 1) / 2);
+      if (this.heap[idx].score >= this.heap[parent].score) break;
+      this.swap(idx, parent);
+      idx = parent;
+    }
+  }
+
+  private bubbleDown(idx: number): void {
+    const length = this.heap.length;
+    while (true) {
+      const left = 2 * idx + 1;
+      const right = left + 1;
+      let smallest = idx;
+      if (left < length && this.heap[left].score < this.heap[smallest].score) {
+        smallest = left;
+      }
+      if (right < length && this.heap[right].score < this.heap[smallest].score) {
+        smallest = right;
+      }
+      if (smallest === idx) break;
+      this.swap(idx, smallest);
+      idx = smallest;
+    }
+  }
+
+  private swap(i: number, j: number): void {
+    const tmp = this.heap[i];
+    this.heap[i] = this.heap[j];
+    this.heap[j] = tmp;
+    this.heap[i].index = i;
+    this.heap[j].index = j;
+  }
+
+  prune(now = Date.now()): void {
+    while (this.heap.length > 0 && this.heap[0].expiresAt <= now) {
+      const expired = this.pop();
+      if (expired) this.map.delete(expired.pairSymbol);
+    }
+  }
+}
+
+export const opportunityStore = new OpportunityStore();

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -25,6 +25,7 @@ const {
   upsertSnapshot,
   broadcastUpdate,
 } = await import('./server/wsServer.js');
+const { opportunityStore } = await import('./core/opportunityStore.js');
 const { bootstrapMatchedLPs } = await import('./bootstrap/pairs.js');
 const { startSyncListener } = await import('./core/syncListener.js');
 
@@ -108,6 +109,12 @@ async function main() {
 
     upsertSnapshot(payload);
     broadcastUpdate(payload);
+
+    opportunityStore.upsert(
+      update.pairSymbol,
+      Number(update.spreadBps ?? '0'),
+      Number(update.liquidityUSD ?? '0'),
+    );
 
     if (update.blockNumber > latestBlockObserved) {
       latestBlockObserved = update.blockNumber;

--- a/backend/src/server/http.test.ts
+++ b/backend/src/server/http.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { AddressInfo } from 'node:net';
+import { setEnv, type Env } from '../config/env.js';
+
+let startHttpServer: any;
+let opportunityStore: any;
+let server: any;
+
+const baseEnv: Env = {
+  RPC_HTTP_URL: 'http://localhost:8545',
+  RPC_WSS_URL: 'ws://localhost:8546',
+  CHAIN_ID: 1,
+  WS_PORT: 0,
+  HTTP_PORT: 0,
+  LOG_LEVEL: 'info',
+  METRICS_PORT: 0,
+  WS_AUTH_TOKEN: 'secret',
+  WETH_ADDRESS: '0x0000000000000000000000000000000000000000',
+  MIN_SPREAD_BPS: 0,
+  MIN_LIQ_USD: 0,
+  MIN_RESERVE: 0,
+  QUOTE_ALLOWLIST: [],
+  QUOTE_DENYLIST: [],
+  LP_SEED_JSON: '',
+  MAX_PAIRS: 50,
+  COLLECT_CONCURRENCY: 2,
+  CHUNK_DELAY_MS: 500,
+  START_INDEX: 0,
+  KILL_SWITCH: false,
+  SIM_ON_SUCCESSFUL_TRADES: false,
+  TRACE_BROADCAST_ENABLED: false,
+};
+
+beforeEach(async () => {
+  setEnv({ ...baseEnv });
+  const mod = await import('./http.js');
+  startHttpServer = mod.startHttpServer;
+  opportunityStore = (await import('../core/opportunityStore.js')).opportunityStore;
+  opportunityStore.clear();
+});
+
+afterEach(() => {
+  server?.close();
+});
+
+function getPort(): number {
+  return (server.address() as AddressInfo).port;
+}
+
+describe('GET /opportunities', () => {
+  it('returns heap snapshot', async () => {
+    opportunityStore.upsert('A/B', 10, 100);
+    opportunityStore.upsert('C/D', 5, 50);
+    server = startHttpServer(0);
+    await new Promise((r) => server.on('listening', r));
+    const port = getPort();
+    const res = await fetch(`http://127.0.0.1:${port}/opportunities`);
+    const data = await res.json();
+    expect(data.size).toBe(2);
+    expect(data.entries[0]).toHaveProperty('pairSymbol');
+  });
+});

--- a/backend/src/server/http.ts
+++ b/backend/src/server/http.ts
@@ -6,6 +6,7 @@ import { compoundedMinOut } from '@blazing/core/utils/slippage.js';
 import { env } from '../config/env.js';
 import { logger } from '../utils/logger.js';
 import { withinGuard, type SimulationResult } from '../config/guard.js';
+import { opportunityStore } from '../core/opportunityStore.js';
 
 const commit = process.env.COMMIT ?? 'unknown';
 const builtAt = process.env.BUILT_AT ?? new Date().toISOString();
@@ -83,6 +84,13 @@ export function startHttpServer(port = env.HTTP_PORT) {
     if (req.method === 'GET' && req.url === '/pairs') {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify(trackedPairs));
+      return;
+    }
+
+    if (req.method === 'GET' && req.url === '/opportunities') {
+      const entries = opportunityStore.snapshot();
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ size: entries.length, entries }));
       return;
     }
 


### PR DESCRIPTION
## Summary
- maintain TTL-based min-heap of opportunities keyed by spread and liquidity
- expose heap snapshot via new `/opportunities` HTTP endpoint
- update heap on sync listener events and add tests for eviction, TTL, and endpoint

## Testing
- `pnpm --filter backend test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689b791d3034832a947f46f53ae27062