### PR TITLE
feat: add guardrails and strategy builder tests

### DIFF
--- a/core.test.ts
+++ b/core.test.ts
@@ -100,8 +100,9 @@ describe('postSyncHooks (arb planner)', () => {
     };
     const scanDiscrepancy = vi.fn().mockResolvedValue(spread);
     const profitGuard = vi.fn().mockReturnValue(true);
-    const execute = vi.fn().mockResolvedValue({ tx: '0x' });
-    const strategy = { execute };
+    const buildCalldata = vi.fn().mockResolvedValue('0x');
+    const dryRun = vi.fn().mockResolvedValue({ txHash: '0x', status: 'success' });
+    const strategy = { shouldExecute: true, reason: null, buildCalldata, dryRun };
     const strategyBuilder = vi.fn().mockReturnValue(strategy);
     const postExecutionHooks = vi.fn();
     const emitSyncEvent = vi.fn();
@@ -135,8 +136,9 @@ describe('postSyncHooks (arb planner)', () => {
       flashFee: 0n,
     });
     expect(strategyBuilder).toHaveBeenCalledWith(syncTrace, spread);
-    expect(execute).toHaveBeenCalled();
-    expect(postExecutionHooks).toHaveBeenCalledWith({ strategy, result: { tx: '0x' } });
+    expect(buildCalldata).toHaveBeenCalled();
+    expect(dryRun).toHaveBeenCalled();
+    expect(postExecutionHooks).toHaveBeenCalledWith({ strategy, result: { txHash: '0x', status: 'success' } });
   });
 
   it('returns early when no spread is found', async () => {

--- a/packages/core/src/core/mixins/withFlashloan.ts
+++ b/packages/core/src/core/mixins/withFlashloan.ts
@@ -1,0 +1,5 @@
+import type { ArbStrategy } from '../../types/strategyTypes.js';
+
+export function withFlashloan<T extends ArbStrategy>(strategy: T): T {
+  return strategy;
+}

--- a/packages/core/src/core/mixins/withPermit2.ts
+++ b/packages/core/src/core/mixins/withPermit2.ts
@@ -1,0 +1,5 @@
+import type { ArbStrategy } from '../../types/strategyTypes.js';
+
+export function withPermit2<T extends ArbStrategy>(strategy: T): T {
+  return strategy;
+}

--- a/packages/core/src/core/strategyBuilder.test.ts
+++ b/packages/core/src/core/strategyBuilder.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { strategyBuilder } from './strategyBuilder.js';
+
+const baseTrace = { gasCostUSD: 5, rv3Block: 0.1 };
+const baseSpread = { estimatedProfit: 10, slippageBps: 50 };
+const config = {
+  minProfitUSD: 1,
+  slippageToleranceBps: 100,
+  maxGasUSD: 10,
+  maxRv: 1,
+};
+
+describe('strategyBuilder guardrails', () => {
+  it('allows execution when all guardrails pass', async () => {
+    const strat = strategyBuilder(baseTrace, baseSpread, config);
+    expect(strat.shouldExecute).toBe(true);
+    expect(strat.reason).toBeNull();
+    await strat.buildCalldata();
+    const res = await strat.dryRun();
+    expect(res.status).toBe('success');
+  });
+
+  it('fails minProfitUSD', () => {
+    const strat = strategyBuilder(baseTrace, { ...baseSpread, estimatedProfit: 0 }, config);
+    expect(strat.shouldExecute).toBe(false);
+    expect(strat.reason).toBe('minProfitUSD');
+  });
+
+  it('fails slippage tolerance', () => {
+    const strat = strategyBuilder(baseTrace, { ...baseSpread, slippageBps: 200 }, config);
+    expect(strat.shouldExecute).toBe(false);
+    expect(strat.reason).toBe('slippageTolerance');
+  });
+
+  it('fails gas sensitivity', () => {
+    const strat = strategyBuilder({ ...baseTrace, gasCostUSD: 20 }, baseSpread, config);
+    expect(strat.shouldExecute).toBe(false);
+    expect(strat.reason).toBe('gasSensitivity');
+  });
+
+  it('fails rv clamp', () => {
+    const strat = strategyBuilder({ ...baseTrace, rv3Block: 5 }, baseSpread, config);
+    expect(strat.shouldExecute).toBe(false);
+    expect(strat.reason).toBe('rvClamp');
+  });
+});

--- a/packages/core/src/core/strategyBuilder.ts
+++ b/packages/core/src/core/strategyBuilder.ts
@@ -1,5 +1,62 @@
-export function strategyBuilder(trace: any, spread: any) {
+import type { ArbStrategy } from '../types/strategyTypes.js';
+import { withFlashloan } from './mixins/withFlashloan.js';
+import { withPermit2 } from './mixins/withPermit2.js';
+import { ExecutionResult } from '../monitorExecution.js';
+
+export interface GuardrailConfig {
+  minProfitUSD: number;
+  slippageToleranceBps: number;
+  maxGasUSD: number;
+  maxRv: number;
+}
+
+const DEFAULT_GUARDRAILS: GuardrailConfig = {
+  minProfitUSD: 0,
+  slippageToleranceBps: 0,
+  maxGasUSD: Infinity,
+  maxRv: Infinity,
+};
+
+function fail(reason: string): ArbStrategy {
   return {
-    execute: async () => ({})
+    shouldExecute: false,
+    reason,
+    buildCalldata: async () => '0x',
+    dryRun: async () => ({ status: 'reverted' } as ExecutionResult),
   };
+}
+
+export function strategyBuilder(
+  trace: any,
+  spread: any,
+  config: Partial<GuardrailConfig> = {},
+): ArbStrategy {
+  const cfg = { ...DEFAULT_GUARDRAILS, ...config };
+  const profit = Number(spread?.estimatedProfit ?? 0);
+  if (profit < cfg.minProfitUSD) return fail('minProfitUSD');
+
+  const slippage = Number(spread?.slippageBps ?? 0);
+  if (slippage > cfg.slippageToleranceBps) return fail('slippageTolerance');
+
+  const gasCost = Number(trace?.gasCostUSD ?? 0);
+  if (gasCost > cfg.maxGasUSD) return fail('gasSensitivity');
+
+  const rv = Number(trace?.rv3Block ?? 0);
+  if (rv > cfg.maxRv) return fail('rvClamp');
+
+  let strategy: ArbStrategy = {
+    shouldExecute: true,
+    reason: null,
+    buildCalldata: async () => '0x',
+    dryRun: async () => ({ status: 'success' } as ExecutionResult),
+  };
+
+  if (process.env.FEATURE_FLASHLOAN === 'true') {
+    strategy = withFlashloan(strategy);
+  }
+  if (process.env.FEATURE_PERMIT2 === 'true') {
+    strategy = withPermit2(strategy);
+  }
+
+  return strategy;
 }

--- a/packages/core/src/hooks/postSyncHooks.ts
+++ b/packages/core/src/hooks/postSyncHooks.ts
@@ -57,8 +57,11 @@ export async function postSyncHooks(log: SyncEventLog) {
     // 6. Build executable strategy from spread + trace
     const strategy = strategyBuilder(syncTrace, spreadResult) as unknown as ArbStrategy;
 
+    if (!strategy.shouldExecute) return;
+
     // 7. Simulate + execute trade (next step: hook into execution engine)
-    const executionResult = (await strategy.execute()) as ExecutionResult;
+    await strategy.buildCalldata();
+    const executionResult = (await strategy.dryRun()) as ExecutionResult;
 
     // 8. Send results to post-trade handling
     await postExecutionHooks({ strategy, result: executionResult });

--- a/packages/core/src/types/strategyTypes.ts
+++ b/packages/core/src/types/strategyTypes.ts
@@ -1,7 +1,10 @@
 import { ExecutionResult } from '../monitorExecution.js';
 
 export interface ArbStrategy {
-  pairSymbol: string;
-  route: string[];
-  execute: () => Promise<ExecutionResult>;
+  pairSymbol?: string;
+  route?: string[];
+  shouldExecute: boolean;
+  reason: string | null;
+  buildCalldata: () => Promise<string>;
+  dryRun: () => Promise<ExecutionResult>;
 }


### PR DESCRIPTION
## Summary
- add typed strategy builder with profit, slippage, gas and RV guardrails
- scaffold flashloan and permit2 mixins behind feature flags
- update sync hooks and tests for new builder API

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689b9a93f880832aac150e73fc79ef73