### PR TITLE
feat: compute spread and scan discrepancies

### DIFF
--- a/packages/core/src/core/scanDiscrepancy.test.ts
+++ b/packages/core/src/core/scanDiscrepancy.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { scanDiscrepancy } from './scanDiscrepancy.js';
+
+describe('scanDiscrepancy', () => {
+  it('applies threshold and determines buy/sell legs', () => {
+    const snaps = [
+      { pairSymbol: 'ETH/USDC', dex: 'uni', reserves: [100, 100000] },
+      { pairSymbol: 'ETH/USDC', dex: 'sushi', reserves: [100, 110000] },
+    ];
+    const res = scanDiscrepancy(snaps, { thresholdBps: 50, minLiquidity: 50 });
+    expect(res).toMatchInlineSnapshot(`
+      {
+        "buyOn": "uni",
+        "estimatedProfit": 0,
+        "sellOn": "sushi",
+        "spread": 1000,
+        "tokenIn": "ETH",
+        "tokenOut": "USDC",
+      }
+    `);
+  });
+
+  it('returns null when below threshold', () => {
+    const snaps = [
+      { pairSymbol: 'ETH/USDC', dex: 'uni', reserves: [100, 100000] },
+      { pairSymbol: 'ETH/USDC', dex: 'sushi', reserves: [100, 100100] },
+    ];
+    expect(
+      scanDiscrepancy(snaps, { thresholdBps: 50, minLiquidity: 50 })
+    ).toMatchInlineSnapshot('null');
+  });
+
+  it('filters out low liquidity pools', () => {
+    const snaps = [
+      { pairSymbol: 'ETH/USDC', dex: 'uni', reserves: [1, 10] },
+      { pairSymbol: 'ETH/USDC', dex: 'sushi', reserves: [100, 110000] },
+    ];
+    expect(
+      scanDiscrepancy(snaps, { thresholdBps: 50, minLiquidity: 50 })
+    ).toBeNull();
+  });
+
+  it('processes 10k snapshots under 100ms', () => {
+    const snaps = Array.from({ length: 10000 }, (_, i) => ({
+      pairSymbol: 'ETH/USDC',
+      dex: `dex${i}`,
+      reserves: [100 + i, 100000 + i],
+    }));
+    const start = performance.now();
+    scanDiscrepancy(snaps);
+    const duration = performance.now() - start;
+    expect(duration).toBeLessThan(100);
+  });
+});

--- a/packages/core/src/core/scanDiscrepancy.ts
+++ b/packages/core/src/core/scanDiscrepancy.ts
@@ -1,3 +1,59 @@
-export async function scanDiscrepancy(trace: any) {
-  return null;
+import { computeSpread } from '../utils/computeSpread.js';
+import { SpreadComputationResult } from '../types/arbitrageTypes.js';
+
+export interface DexSnapshot {
+  pairSymbol: string;
+  dex: string;
+  reserves: [number, number];
+}
+
+export interface ScanOptions {
+  minLiquidity?: number;
+  thresholdBps?: number;
+}
+
+/**
+ * Scans a set of DEX snapshots for arbitrage opportunities.
+ * Prices are normalized as tokenOut per tokenIn.
+ */
+export function scanDiscrepancy(
+  snapshots: DexSnapshot[],
+  opts: ScanOptions = {}
+): SpreadComputationResult | null {
+  const { minLiquidity = 0, thresholdBps = 0 } = opts;
+  if (!snapshots.length) return null;
+
+  const filtered = snapshots.filter(
+    (s) => s.reserves[0] >= minLiquidity && s.reserves[1] >= minLiquidity
+  );
+  if (filtered.length < 2) return null;
+
+  // Compute normalized prices
+  const prices = filtered.map((s) => ({
+    dex: s.dex,
+    price: s.reserves[1] / s.reserves[0],
+  }));
+
+  // Find min and max price
+  let min = prices[0];
+  let max = prices[0];
+  for (let i = 1; i < prices.length; i++) {
+    if (prices[i].price < min.price) min = prices[i];
+    if (prices[i].price > max.price) max = prices[i];
+  }
+  if (min.dex === max.dex) return null;
+
+  const spread = computeSpread(min, max);
+  if (!spread || spread.spreadBps < thresholdBps) return null;
+
+  const [tokenIn, tokenOut] = filtered[0].pairSymbol.split('/');
+
+  return {
+    tokenIn,
+    tokenOut,
+    spread: spread.spreadBps,
+    buyOn: spread.buyDex,
+    sellOn: spread.sellDex,
+    estimatedProfit: 0,
+  };
 }

--- a/packages/core/src/utils/computeSpread.test.ts
+++ b/packages/core/src/utils/computeSpread.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { computeSpread } from './computeSpread.js';
+
+describe('computeSpread', () => {
+  it('is symmetric regardless of input order', () => {
+    const a = { dex: 'dexA', price: 100 };
+    const b = { dex: 'dexB', price: 110 };
+    const r1 = computeSpread(a, b);
+    const r2 = computeSpread(b, a);
+    expect(r1).toEqual(r2);
+    expect(r1).toMatchInlineSnapshot(`
+      {
+        "buyDex": "dexA",
+        "sellDex": "dexB",
+        "spreadBps": 1000,
+      }
+    `);
+  });
+});

--- a/packages/core/src/utils/computeSpread.ts
+++ b/packages/core/src/utils/computeSpread.ts
@@ -1,0 +1,25 @@
+export interface PricePoint {
+  dex: string;
+  price: number;
+}
+
+export interface SpreadComputation {
+  spreadBps: number;
+  buyDex: string;
+  sellDex: string;
+}
+
+/**
+ * Computes the spread in basis points between two normalized prices.
+ * Returns the direction to buy and sell based on which price is lower.
+ */
+export function computeSpread(a: PricePoint, b: PricePoint): SpreadComputation | null {
+  if (a.price === b.price) return null;
+  const [buy, sell] = a.price < b.price ? [a, b] : [b, a];
+  const spreadBps = ((sell.price - buy.price) / buy.price) * 10_000;
+  return {
+    spreadBps,
+    buyDex: buy.dex,
+    sellDex: sell.dex,
+  };
+}


### PR DESCRIPTION
## Summary
- add pure spread computation helper
- implement discrepancy scanner with liquidity, spread threshold, and trade direction logic
- add symmetry, threshold, and performance tests

## Testing
- `pnpm test`
- `pnpm --filter @blazing/core lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689bac1f46d8832aada07dac493f2ef1