### PR TITLE
Stringify broadcasted reserves and arb metrics

### DIFF
--- a/core.test.ts
+++ b/core.test.ts
@@ -125,11 +125,21 @@ describe('postSyncHooks (arb planner)', () => {
     expect(emitSyncEvent).toHaveBeenCalledWith({
       pairSymbol: syncTrace.pairSymbol,
       dex: syncTrace.dex,
-      reserves: syncTrace.reservesAfter,
+      reserves: {
+        reserve0: String(syncTrace.reservesAfter[0]),
+        reserve1: String(syncTrace.reservesAfter[1])
+      },
       timestamp: syncTrace.timestamp
     });
     expect(scanDiscrepancy).toHaveBeenCalledWith(syncTrace);
-    expect(emitArbOpportunity).toHaveBeenCalledWith(spread);
+    expect(emitArbOpportunity).toHaveBeenCalledWith({
+      tokenIn: spread.tokenIn,
+      tokenOut: spread.tokenOut,
+      spread: String(spread.spread),
+      buyOn: spread.buyOn,
+      sellOn: spread.sellOn,
+      estimatedProfit: String(spread.estimatedProfit)
+    });
     expect(profitGuard).toHaveBeenCalledWith({
       expectedProceeds: BigInt(Math.floor(spread.estimatedProfit ?? 0)),
       gasCost: 0n,

--- a/packages/core/src/hooks/postSyncHooks.ts
+++ b/packages/core/src/hooks/postSyncHooks.ts
@@ -27,7 +27,10 @@ export async function postSyncHooks(log: SyncEventLog) {
     emitSyncEvent({
       pairSymbol: syncTrace.pairSymbol,
       dex: syncTrace.dex,
-      reserves: syncTrace.reservesAfter,
+      reserves: {
+        reserve0: String(syncTrace.reservesAfter[0]),
+        reserve1: String(syncTrace.reservesAfter[1])
+      },
       timestamp: syncTrace.timestamp
     });
 
@@ -40,10 +43,10 @@ export async function postSyncHooks(log: SyncEventLog) {
     emitArbOpportunity({
       tokenIn: spreadResult.tokenIn,
       tokenOut: spreadResult.tokenOut,
-      spread: spreadResult.spread,
+      spread: String(spreadResult.spread),
       buyOn: spreadResult.buyOn,
       sellOn: spreadResult.sellOn,
-      estimatedProfit: spreadResult.estimatedProfit
+      estimatedProfit: String(spreadResult.estimatedProfit)
     });
 
     // 5. Run profit guard to validate thresholds


### PR DESCRIPTION
## Summary
- Emit sync event reserves as strings under reserve0/reserve1
- Broadcast arbitrage opportunity numeric fields as strings
- Update tests for new broadcast formats

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689bfeba8fc4832ab069e381a46a139d