### PR TITLE
Allow numeric values in ABIE events

### DIFF
--- a/packages/core/src/abie/broadcaster/eventTypes.ts
+++ b/packages/core/src/abie/broadcaster/eventTypes.ts
@@ -24,16 +24,16 @@ export interface ABIEEventPayloads {
   sync_event: {
     pairSymbol: string;
     dex: string;
-    reserves: { reserve0: string; reserve1: string };
-    timestamp: number;
+    reserves: { reserve0: string | number; reserve1: string | number };
+    timestamp: string | number;
   };
   arb_opportunity: {
     tokenIn: string;
     tokenOut: string;
-    spread: string;
+    spread: string | number;
     buyOn: string;
     sellOn: string;
-    estimatedProfit: string;
+    estimatedProfit: string | number;
   };
   execution_result: {
     txHash: string;


### PR DESCRIPTION
## Summary
- accept numbers in `sync_event` and `arb_opportunity` payloads
- convert number payload values to strings before broadcasting

## Testing
- `pnpm test`
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689c02d39128832a9ed76a809b774e75