### PR TITLE
feat: cache ABI lookups and decode selectors via ethers

### DIFF
--- a/packages/core/src/utils/decodeSelector.test.ts
+++ b/packages/core/src/utils/decodeSelector.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { decodeSelector, registerSelector, clearSelectorCache } from './decodeSelector.js';
+import { Interface } from 'ethers';
+
+const iface = new Interface(['function transfer(address to, uint256 value)']);
+const data = iface.encodeFunctionData('transfer', [
+  '0x000000000000000000000000000000000000dEaD',
+  1n,
+]);
+const selector = data.slice(0, 10);
+
+describe('decodeSelector', () => {
+  beforeEach(() => {
+    clearSelectorCache();
+    registerSelector(selector, ['function transfer(address to, uint256 value)']);
+  });
+
+  it('decodes calldata using registered ABI', () => {
+    const decoded = decodeSelector(selector, data);
+    expect(decoded).toEqual({
+      method: 'transfer',
+      args: ['0x000000000000000000000000000000000000dEaD', 1n],
+    });
+  });
+});

--- a/packages/core/src/utils/fetchAbiSignature.test.ts
+++ b/packages/core/src/utils/fetchAbiSignature.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { fetchAbiSignature } from './fetchAbiSignature.js';
+import { clearSelectorCache } from './decodeSelector.js';
+
+describe('fetchAbiSignature', () => {
+  beforeEach(() => {
+    clearSelectorCache();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches from openchain and caches result', async () => {
+    const selector = '0x12345678';
+    const responseData = {
+      result: {
+        function: {
+          [selector]: [
+            {
+              function: {
+                name: 'foo',
+                inputs: [{ name: 'bar', type: 'uint256' }],
+                outputs: [],
+                stateMutability: 'nonpayable',
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    const fetchMock = vi.fn(async () => ({ ok: true, json: async () => responseData } as any));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const abi1 = await fetchAbiSignature(selector);
+    expect(abi1).not.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const abi2 = await fetchAbiSignature(selector);
+    expect(abi2).not.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1); // cached
+  });
+
+  it('falls back to 4byte when openchain fails', async () => {
+    const selector = '0xdeadbeef';
+    const fourByteData = {
+      results: [{ text_signature: 'baz(uint256)' }],
+    };
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('openchain')) {
+        return { ok: true, json: async () => ({ result: { function: {} } }) } as any;
+      }
+      return { ok: true, json: async () => fourByteData } as any;
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const abi = await fetchAbiSignature(selector);
+    expect(abi).toEqual(['function baz(uint256)']);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/src/utils/fetchAbiSignature.ts
+++ b/packages/core/src/utils/fetchAbiSignature.ts
@@ -1,3 +1,44 @@
-export async function fetchAbiSignature(selector: string): Promise<any> {
+import { selectorAbiCache } from './selectorCache.js';
+import type { InterfaceAbi } from 'ethers';
+
+export async function fetchAbiSignature(selector: string): Promise<InterfaceAbi | null> {
+  const cached = selectorAbiCache.get(selector);
+  if (cached) return cached;
+
+  // Try OpenChain first
+  try {
+    const res = await fetch(`https://api.openchain.xyz/signature-database/v1/lookup?function=${selector}`);
+    if (res.ok) {
+      const data = await res.json();
+      const entry = data?.result?.function?.[selector]?.[0]?.function;
+      if (entry && entry.name) {
+        const abiItem = {
+          type: 'function',
+          name: entry.name,
+          inputs: entry.inputs || [],
+          outputs: entry.outputs || [],
+          stateMutability: entry.stateMutability || 'nonpayable'
+        };
+        const abi: InterfaceAbi = [abiItem];
+        selectorAbiCache.set(selector, abi);
+        return abi;
+      }
+    }
+  } catch {}
+
+  // Fallback to 4byte directory
+  try {
+    const res = await fetch(`https://www.4byte.directory/api/v1/signatures/?hex_signature=${selector}`);
+    if (res.ok) {
+      const data = await res.json();
+      const text = data?.results?.[0]?.text_signature;
+      if (text) {
+        const abi: InterfaceAbi = [`function ${text}`];
+        selectorAbiCache.set(selector, abi);
+        return abi;
+      }
+    }
+  } catch {}
+
   return null;
 }

--- a/packages/core/src/utils/selectorCache.ts
+++ b/packages/core/src/utils/selectorCache.ts
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import path from 'path';
+
+const CACHE_FILE = path.join(process.cwd(), 'selector-cache.json');
+
+class LRUCache<K, V> {
+  private cache = new Map<K, V>();
+  constructor(private readonly limit = 100) {
+    this.load();
+    process.on('exit', () => this.persist());
+  }
+
+  private load() {
+    try {
+      if (fs.existsSync(CACHE_FILE)) {
+        const data = JSON.parse(fs.readFileSync(CACHE_FILE, 'utf-8'));
+        this.cache = new Map(data);
+      }
+    } catch {}
+  }
+
+  private persist() {
+    try {
+      fs.writeFileSync(CACHE_FILE, JSON.stringify([...this.cache.entries()]));
+    } catch {}
+  }
+
+  get(key: K): V | undefined {
+    if (!this.cache.has(key)) return undefined;
+    const val = this.cache.get(key)!;
+    this.cache.delete(key);
+    this.cache.set(key, val);
+    return val;
+  }
+
+  set(key: K, value: V) {
+    if (this.cache.has(key)) this.cache.delete(key);
+    this.cache.set(key, value);
+    if (this.cache.size > this.limit) {
+      const first = this.cache.keys().next().value;
+      this.cache.delete(first);
+    }
+  }
+
+  clear() {
+    this.cache.clear();
+  }
+}
+
+export const selectorAbiCache = new LRUCache<string, any>();


### PR DESCRIPTION
## Summary
- add LRU cache for selector->ABI data
- decode selectors using ethers Interface with cached or supplied ABI
- fetch ABI signatures from OpenChain/4byte and cache results
- add unit tests for decoding and ABI fetching

## Testing
- `pnpm test`
- `pnpm --filter @blazing/core test`


------
https://chatgpt.com/codex/tasks/task_e_689c1dc7db78832a954c3b521f5dadfe