### PR TITLE
feat: parallel trace decoding and multicall reserve caching

### DIFF
--- a/backend/src/simulateUnknownTx.test.ts
+++ b/backend/src/simulateUnknownTx.test.ts
@@ -27,9 +27,10 @@ describe('simulateUnknownTx', () => {
     const fetchAbiSignatureMock = vi.fn().mockResolvedValue(null);
     vi.doMock('@blazing/core/utils/fetchAbiSignature', () => ({ fetchAbiSignature: fetchAbiSignatureMock }));
     const parsedTrace = { contract: '0x1', from: '0x2', method: 'foo', args: ['bar'], ethTransferred: '0', gasUsed: '0', input: '0x12345678abcdef', depth: 0, children: [] };
-    const parseTraceMock = vi.fn().mockReturnValue(parsedTrace);
+    const parseTraceMock = vi.fn().mockResolvedValue(parsedTrace);
     vi.doMock('@blazing/core/utils/traceParsers', () => ({ parseTrace: parseTraceMock }));
     vi.doMock('@blazing/core/utils/fetchTokenPrice', () => ({ fetchTokenPrice: vi.fn().mockResolvedValue(1) }));
+    vi.doMock('@blazing/core/utils/fetchReserves', () => ({ fetchReserves: vi.fn().mockResolvedValue({}) }));
 
     const { simulateUnknownTx } = await import('@blazing/core/abie/simulation/simulateUnknownTx');
     const result = await simulateUnknownTx({ txHash: '0xabc' });
@@ -48,8 +49,9 @@ describe('simulateUnknownTx', () => {
     vi.doMock('@blazing/core/utils/decodeSelector', () => ({ decodeSelector: vi.fn() }));
     vi.doMock('@blazing/core/utils/decodeRawArgsHex', () => ({ decodeRawArgsHex: vi.fn() }));
     vi.doMock('@blazing/core/utils/fetchAbiSignature', () => ({ fetchAbiSignature: vi.fn() }));
-    vi.doMock('@blazing/core/utils/traceParsers', () => ({ parseTrace: vi.fn() }));
+    vi.doMock('@blazing/core/utils/traceParsers', () => ({ parseTrace: vi.fn().mockResolvedValue({}) }));
     vi.doMock('@blazing/core/utils/fetchTokenPrice', () => ({ fetchTokenPrice: vi.fn().mockResolvedValue(1) }));
+    vi.doMock('@blazing/core/utils/fetchReserves', () => ({ fetchReserves: vi.fn().mockResolvedValue({}) }));
 
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { simulateUnknownTx } = await import('@blazing/core/abie/simulation/simulateUnknownTx');
@@ -73,8 +75,9 @@ describe('simulateUnknownTx', () => {
     vi.doMock('@blazing/core/utils/decodeSelector', () => ({ decodeSelector: vi.fn(), registerSelector: vi.fn(), clearSelectorCache: vi.fn() }));
     vi.doMock('@blazing/core/utils/decodeRawArgsHex', () => ({ decodeRawArgsHex: vi.fn() }));
     vi.doMock('@blazing/core/utils/fetchAbiSignature', () => ({ fetchAbiSignature: vi.fn() }));
-    vi.doMock('@blazing/core/utils/traceParsers', () => ({ parseTrace: vi.fn() }));
+    vi.doMock('@blazing/core/utils/traceParsers', () => ({ parseTrace: vi.fn().mockResolvedValue({}) }));
     vi.doMock('@blazing/core/utils/fetchTokenPrice', () => ({ fetchTokenPrice: vi.fn().mockResolvedValue(1) }));
+    vi.doMock('@blazing/core/utils/fetchReserves', () => ({ fetchReserves: vi.fn().mockResolvedValue({}) }));
 
     const { simulateUnknownTx } = await import('@blazing/core/abie/simulation/simulateUnknownTx');
     const promise = simulateUnknownTx({ txHash: '0xabc' });
@@ -97,9 +100,10 @@ describe('simulateUnknownTx', () => {
     vi.doMock('@blazing/core/utils/decodeRawArgsHex', () => ({ decodeRawArgsHex: vi.fn() }));
     vi.doMock('@blazing/core/utils/fetchAbiSignature', () => ({ fetchAbiSignature: vi.fn() }));
     const parsedTrace = { contract: '0x1', from: '0x2', method: 'foo', args: [], ethTransferred: '0', gasUsed: '0', input: '0x12345678abcdef', depth: 0, children: [] };
-    const parseTraceMock = vi.fn().mockReturnValue(parsedTrace);
+    const parseTraceMock = vi.fn().mockResolvedValue(parsedTrace);
     vi.doMock('@blazing/core/utils/traceParsers', () => ({ parseTrace: parseTraceMock }));
     vi.doMock('@blazing/core/utils/fetchTokenPrice', () => ({ fetchTokenPrice: vi.fn().mockResolvedValue(1) }));
+    vi.doMock('@blazing/core/utils/fetchReserves', () => ({ fetchReserves: vi.fn().mockResolvedValue({}) }));
     const { traceCache } = await import('@blazing/core/utils/traceCache');
     traceCache.clear();
 
@@ -145,6 +149,7 @@ describe('simulateUnknownTx', () => {
     }));
     vi.doMock('@blazing/core/utils/fetchAbiSignature', () => ({ fetchAbiSignature: vi.fn() }));
     vi.doMock('@blazing/core/utils/fetchTokenPrice', () => ({ fetchTokenPrice: vi.fn().mockResolvedValue(1) }));
+    vi.doMock('@blazing/core/utils/fetchReserves', () => ({ fetchReserves: vi.fn().mockResolvedValue({}) }));
     vi.doUnmock('@blazing/core/utils/traceParsers');
     vi.doUnmock('@blazing/core/utils/decodeRawArgsHex');
 
@@ -201,8 +206,9 @@ describe('simulateUnknownTx', () => {
     vi.doMock('@blazing/core/utils/decodeSelector', () => ({ decodeSelector: vi.fn() }));
     vi.doMock('@blazing/core/utils/decodeRawArgsHex', () => ({ decodeRawArgsHex: vi.fn() }));
     vi.doMock('@blazing/core/utils/fetchAbiSignature', () => ({ fetchAbiSignature: vi.fn() }));
-    vi.doMock('@blazing/core/utils/traceParsers', () => ({ parseTrace: vi.fn().mockReturnValue({}) }));
+    vi.doMock('@blazing/core/utils/traceParsers', () => ({ parseTrace: vi.fn().mockResolvedValue({}) }));
     vi.doMock('@blazing/core/utils/fetchTokenPrice', () => ({ fetchTokenPrice: vi.fn().mockResolvedValue(1) }));
+    vi.doMock('@blazing/core/utils/fetchReserves', () => ({ fetchReserves: vi.fn().mockResolvedValue({}) }));
 
     const { simulateUnknownTx } = await import('@blazing/core/abie/simulation/simulateUnknownTx');
     const result = await simulateUnknownTx({ txHash: '0xabc' });

--- a/packages/core/src/utils/fetchReserves.test.ts
+++ b/packages/core/src/utils/fetchReserves.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe('fetchReserves', () => {
+  it('uses multicall and caches per block', async () => {
+    const multicallMock = vi
+      .fn()
+      .mockResolvedValue([
+        { result: [1n, 2n, 0n] },
+        { result: [3n, 4n, 0n] },
+      ]);
+    vi.doMock('../clients/viemClient', () => ({
+      viemClient: { multicall: multicallMock },
+    }));
+
+    const { fetchReserves, clearReserveCache } = await import('./fetchReserves.js');
+    clearReserveCache();
+
+    const pools = ['0x1', '0x2'];
+    const res1 = await fetchReserves(pools, 1n);
+    expect(multicallMock).toHaveBeenCalledTimes(1);
+    expect(res1['0x1']).toEqual([1n, 2n]);
+
+    const res2 = await fetchReserves(pools, 1n);
+    expect(multicallMock).toHaveBeenCalledTimes(1); // cached
+    expect(res2['0x2']).toEqual([3n, 4n]);
+  });
+});

--- a/packages/core/src/utils/fetchReserves.ts
+++ b/packages/core/src/utils/fetchReserves.ts
@@ -1,0 +1,50 @@
+import { viemClient } from '../clients/viemClient.js';
+import { UNISWAP_PAIR_ABI } from '../abi-cache/PAIR/uniswapV2Pair.js';
+
+// Cache reserves keyed by block number then pool address
+const reserveCache = new Map<bigint, Map<string, [bigint, bigint]>>();
+
+export async function fetchReserves(
+  pools: string[],
+  blockNumber: bigint
+): Promise<Record<string, [bigint, bigint]>> {
+  let blockCache = reserveCache.get(blockNumber);
+  if (!blockCache) {
+    blockCache = new Map();
+    reserveCache.set(blockNumber, blockCache);
+  }
+
+  const missing = pools.filter((p) => !blockCache!.has(p));
+  if (missing.length > 0) {
+    const contracts = missing.map((address) => ({
+      address,
+      abi: UNISWAP_PAIR_ABI,
+      functionName: 'getReserves' as const,
+    }));
+    const results = await viemClient.multicall({
+      contracts,
+      blockNumber,
+      allowFailure: true,
+    });
+    missing.forEach((addr, i) => {
+      const res = results[i];
+      if (res && res.result) {
+        const [r0, r1] = res.result as readonly [bigint, bigint, bigint];
+        blockCache!.set(addr, [r0, r1]);
+      } else {
+        blockCache!.set(addr, [0n, 0n]);
+      }
+    });
+  }
+
+  const out: Record<string, [bigint, bigint]> = {};
+  for (const addr of pools) {
+    const item = blockCache!.get(addr);
+    if (item) out[addr] = item;
+  }
+  return out;
+}
+
+export function clearReserveCache() {
+  reserveCache.clear();
+}

--- a/packages/core/src/utils/traceParsers.ts
+++ b/packages/core/src/utils/traceParsers.ts
@@ -12,12 +12,15 @@ interface ViemTraceCall {
   calls?: ViemTraceCall[];
 }
 
-export function parseTrace(trace: ViemTraceCall, decoded?: any): TraceResult {
+export async function parseTrace(
+  trace: ViemTraceCall,
+  decoded?: any
+): Promise<TraceResult> {
   const cache = new Map<string, any>();
   const rootSelector = trace.input?.slice(0, 10);
   if (decoded && rootSelector) cache.set(rootSelector, decoded);
 
-  function dfs(call: ViemTraceCall, depth: number): TraceResult {
+  async function dfs(call: ViemTraceCall, depth: number): Promise<TraceResult> {
     const selector = call.input?.slice(0, 10) || '';
     let info: any;
     if (cache.has(selector)) info = cache.get(selector);
@@ -40,7 +43,9 @@ export function parseTrace(trace: ViemTraceCall, decoded?: any): TraceResult {
     };
 
     if (call.calls && call.calls.length > 0) {
-      node.children = call.calls.map((c) => dfs(c, depth + 1));
+      node.children = await Promise.all(
+        call.calls.map((c) => dfs(c, depth + 1))
+      );
     }
 
     return node;


### PR DESCRIPTION
## Summary
- Decode transaction traces concurrently with Promise.all.
- Fetch multiple pool reserves via multicall and cache by block.
- Use cached reserves in simulations for flash-loan sizing.

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689c34f2eaa8832a8767066787075936