### PR TITLE
Persist ABI cache across runs

### DIFF
--- a/backend/src/simulateUnknownTx.test.ts
+++ b/backend/src/simulateUnknownTx.test.ts
@@ -7,6 +7,9 @@ beforeEach(() => {
   try {
     fs.unlinkSync(path.join(process.cwd(), 'trace-cache.json'));
   } catch {}
+  try {
+    fs.unlinkSync(path.join(process.cwd(), 'abi-cache.json'));
+  } catch {}
 });
 
 describe('simulateUnknownTx', () => {
@@ -72,7 +75,7 @@ describe('simulateUnknownTx', () => {
     vi.doMock('@blazing/core/clients/viemClient', () => ({
       viemClient: { debug_traceTransaction: debugTraceMock }
     }));
-    vi.doMock('@blazing/core/utils/decodeSelector', () => ({ decodeSelector: vi.fn(), registerSelector: vi.fn(), clearSelectorCache: vi.fn() }));
+    vi.doMock('@blazing/core/utils/decodeSelector', () => ({ decodeSelector: vi.fn(), registerSelector: vi.fn(), clearAbiCache: vi.fn() }));
     vi.doMock('@blazing/core/utils/decodeRawArgsHex', () => ({ decodeRawArgsHex: vi.fn() }));
     vi.doMock('@blazing/core/utils/fetchAbiSignature', () => ({ fetchAbiSignature: vi.fn() }));
     vi.doMock('@blazing/core/utils/traceParsers', () => ({ parseTrace: vi.fn().mockResolvedValue({}) }));
@@ -96,7 +99,7 @@ describe('simulateUnknownTx', () => {
     vi.doMock('@blazing/core/clients/viemClient', () => ({
       viemClient: { debug_traceTransaction: debugTraceMock }
     }));
-    vi.doMock('@blazing/core/utils/decodeSelector', () => ({ decodeSelector: () => ({ method: 'foo', args: [] }), registerSelector: vi.fn(), clearSelectorCache: vi.fn() }));
+    vi.doMock('@blazing/core/utils/decodeSelector', () => ({ decodeSelector: () => ({ method: 'foo', args: [] }), registerSelector: vi.fn(), clearAbiCache: vi.fn() }));
     vi.doMock('@blazing/core/utils/decodeRawArgsHex', () => ({ decodeRawArgsHex: vi.fn() }));
     vi.doMock('@blazing/core/utils/fetchAbiSignature', () => ({ fetchAbiSignature: vi.fn() }));
     const parsedTrace = { contract: '0x1', from: '0x2', method: 'foo', args: [], ethTransferred: '0', gasUsed: '0', input: '0x12345678abcdef', depth: 0, children: [] };
@@ -164,7 +167,7 @@ describe('simulateUnknownTx', () => {
     vi.doMock('@blazing/core/utils/decodeSelector', () => ({
       decodeSelector: decodeSelectorMock,
       registerSelector: vi.fn(),
-      clearSelectorCache: vi.fn()
+      clearAbiCache: vi.fn()
     }));
 
     const { traceCache } = await import('@blazing/core/utils/traceCache');

--- a/packages/core/src/utils/abiCache.ts
+++ b/packages/core/src/utils/abiCache.ts
@@ -1,7 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
-const CACHE_FILE = path.join(process.cwd(), 'selector-cache.json');
+// Persist ABI cache so selectors don't need to be re-fetched every run
+const CACHE_FILE = path.join(process.cwd(), 'abi-cache.json');
 
 class LRUCache<K, V> {
   private cache = new Map<K, V>();
@@ -48,3 +49,10 @@ class LRUCache<K, V> {
 }
 
 export const selectorAbiCache = new LRUCache<string, any>();
+
+export function clearAbiCache() {
+  selectorAbiCache.clear();
+  try {
+    fs.unlinkSync(CACHE_FILE);
+  } catch {}
+}

--- a/packages/core/src/utils/decodeSelector.test.ts
+++ b/packages/core/src/utils/decodeSelector.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { decodeSelector, registerSelector, clearSelectorCache } from './decodeSelector.js';
+import { decodeSelector, registerSelector, clearAbiCache } from './decodeSelector.js';
 import { Interface } from 'ethers';
 
 const iface = new Interface(['function transfer(address to, uint256 value)']);
@@ -11,7 +11,7 @@ const selector = data.slice(0, 10);
 
 describe('decodeSelector', () => {
   beforeEach(() => {
-    clearSelectorCache();
+    clearAbiCache();
     registerSelector(selector, ['function transfer(address to, uint256 value)']);
   });
 

--- a/packages/core/src/utils/decodeSelector.ts
+++ b/packages/core/src/utils/decodeSelector.ts
@@ -1,13 +1,11 @@
 import { Interface, type InterfaceAbi } from 'ethers';
-import { selectorAbiCache } from './selectorCache.js';
+import { selectorAbiCache, clearAbiCache } from './abiCache.js';
 
 export function registerSelector(selector: string, abi: InterfaceAbi) {
   selectorAbiCache.set(selector, abi);
 }
 
-export function clearSelectorCache() {
-  selectorAbiCache.clear();
-}
+export { clearAbiCache };
 
 export function decodeSelector(selector: string, callData: string, abi?: InterfaceAbi): any {
   const entry = abi || selectorAbiCache.get(selector);

--- a/packages/core/src/utils/fetchAbiSignature.test.ts
+++ b/packages/core/src/utils/fetchAbiSignature.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { fetchAbiSignature } from './fetchAbiSignature.js';
-import { clearSelectorCache } from './decodeSelector.js';
+import { clearAbiCache } from './decodeSelector.js';
 
 describe('fetchAbiSignature', () => {
   beforeEach(() => {
-    clearSelectorCache();
+    clearAbiCache();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });

--- a/packages/core/src/utils/fetchAbiSignature.ts
+++ b/packages/core/src/utils/fetchAbiSignature.ts
@@ -1,4 +1,4 @@
-import { selectorAbiCache } from './selectorCache.js';
+import { selectorAbiCache } from './abiCache.js';
 import type { InterfaceAbi } from 'ethers';
 
 export async function fetchAbiSignature(selector: string): Promise<InterfaceAbi | null> {


### PR DESCRIPTION
## Summary
- Persist ABI selector cache to `abi-cache.json` and reload on startup
- Expose `clearAbiCache()` for tests and maintenance
- Update decoding utilities and tests to use the new cache helper

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689c368751e8832ab6c383b044676c03