### PR TITLE
chore(core): add viem and node types

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,12 +19,14 @@
     "dotenv": "^17.2.1",
     "pino": "^9.8.0",
     "prom-client": "^15.1.3",
+    "viem": "^2.13.7",
     "@t-op-arb-bot/types": "workspace:*"
   },
   "devDependencies": {
-    "typescript": "^5.9.2",
+    "typescript": "^5.5.4",
     "eslint": "^9.33.0",
     "vitest": "^3.2.4",
-    "@types/ws": "^8.5.10"
+    "@types/ws": "^8.5.10",
+    "@types/node": "^20.12.12"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
+      viem:
+        specifier: ^2.13.7
+        version: 2.33.3(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       ws:
         specifier: ^8.18.3
         version: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -146,6 +149,9 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
     devDependencies:
+      '@types/node':
+        specifier: ^20.12.12
+        version: 20.19.10
       '@types/ws':
         specifier: ^8.5.10
         version: 8.18.1
@@ -153,11 +159,11 @@ importers:
         specifier: ^9.33.0
         version: 9.33.0
       typescript:
-        specifier: ^5.9.2
+        specifier: ^5.5.4
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.2.1)(jsdom@24.1.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(tsx@4.20.3)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.10)(jsdom@24.1.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(tsx@4.20.3)
 
   packages/types:
     dependencies:
@@ -1104,6 +1110,9 @@ packages:
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node@20.19.10':
+    resolution: {integrity: sha512-iAFpG6DokED3roLSP0K+ybeDdIX6Bc0Vd3mLW5uDqThPWtNos3E+EqOM11mPQHKzfWHqEBuLjIlsBQQ8CsISmQ==}
 
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
@@ -2856,6 +2865,9 @@ packages:
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@7.10.0:
     resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
 
@@ -4555,6 +4567,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node@20.19.10':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@22.7.5':
     dependencies:
       undici-types: 6.19.8
@@ -4578,7 +4594,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 24.2.1
+      '@types/node': 20.19.10
 
   '@vanilla-extract/css@1.17.3':
     dependencies:
@@ -4641,6 +4657,14 @@ snapshots:
       magic-string: 0.30.17
     optionalDependencies:
       vite: 5.4.19(@types/node@24.2.1)
+
+  '@vitest/mocker@3.2.4(vite@7.1.1(@types/node@20.19.10)(tsx@4.20.3))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 7.1.1(@types/node@20.19.10)(tsx@4.20.3)
 
   '@vitest/mocker@3.2.4(vite@7.1.1(@types/node@24.2.1)(tsx@4.20.3))':
     dependencies:
@@ -6840,6 +6864,8 @@ snapshots:
 
   undici-types@6.19.8: {}
 
+  undici-types@6.21.0: {}
+
   undici-types@7.10.0: {}
 
   universalify@0.2.0: {}
@@ -6978,6 +7004,27 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@3.2.4(@types/node@20.19.10)(tsx@4.20.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.1.1(@types/node@20.19.10)(tsx@4.20.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@3.2.4(@types/node@24.2.1)(tsx@4.20.3):
     dependencies:
       cac: 6.7.14
@@ -7007,6 +7054,19 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.2.1
       fsevents: 2.3.3
+
+  vite@7.1.1(@types/node@20.19.10)(tsx@4.20.3):
+    dependencies:
+      esbuild: 0.25.8
+      fdir: 6.4.6(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.46.2
+      tinyglobby: 0.2.14
+    optionalDependencies:
+      '@types/node': 20.19.10
+      fsevents: 2.3.3
+      tsx: 4.20.3
 
   vite@7.1.1(@types/node@24.2.1)(tsx@4.20.3):
     dependencies:
@@ -7056,6 +7116,49 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.10)(jsdom@24.1.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(tsx@4.20.3):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.1.1(@types/node@20.19.10)(tsx@4.20.3))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.1
+      debug: 4.4.1
+      expect-type: 1.2.2
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.1.1(@types/node@20.19.10)(tsx@4.20.3)
+      vite-node: 3.2.4(@types/node@20.19.10)(tsx@4.20.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 20.19.10
+      jsdom: 24.1.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.2.1)(jsdom@24.1.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(tsx@4.20.3):
     dependencies:


### PR DESCRIPTION
## Summary
- add `viem` runtime dependency for core package
- use `@types/node` and pin TypeScript to `^5.5.4`
- update lockfile with new dependencies

## Testing
- `pnpm i`

------
https://chatgpt.com/codex/tasks/task_e_689cc3117904832ab20a89d01acfd1e7