### PR TITLE
chore(core): update tsconfig

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,15 +1,15 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2020"],
+    "types": ["node"],
+    "strict": true,
     "outDir": "dist",
-    "declaration": true,
-    "composite": true,
-    "baseUrl": "src",
-    "paths": {
-      "@/*": ["*"]
-    },
-    "strict": false
+    "rootDir": "src",
+    "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- target ES2020 NodeNext modules and resolution for core package
- enable strict mode and node typings
- drop unused baseUrl, paths, composite settings

## Testing
- `pnpm test`
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_689cc485f874832aafde2906ed7c9baa