### PR TITLE
refactor: use readContracts for reserve fetching

### DIFF
--- a/packages/core/src/utils/fetchReserves.test.ts
+++ b/packages/core/src/utils/fetchReserves.test.ts
@@ -5,15 +5,13 @@ beforeEach(() => {
 });
 
 describe('fetchReserves', () => {
-  it('uses multicall and caches per block', async () => {
-    const multicallMock = vi
-      .fn()
-      .mockResolvedValue([
-        { result: [1n, 2n, 0n] },
-        { result: [3n, 4n, 0n] },
-      ]);
+  it('uses readContracts and caches per block', async () => {
+    const readContractsMock = vi.fn().mockResolvedValue([
+      [1n, 2n, 0n],
+      [3n, 4n, 0n],
+    ]);
     vi.doMock('../clients/viemClient', () => ({
-      viemClient: { multicall: multicallMock },
+      publicClient: { readContracts: readContractsMock },
     }));
 
     const { fetchReserves, clearReserveCache } = await import('./fetchReserves.js');
@@ -21,11 +19,11 @@ describe('fetchReserves', () => {
 
     const pools = ['0x1', '0x2'];
     const res1 = await fetchReserves(pools, 1n);
-    expect(multicallMock).toHaveBeenCalledTimes(1);
+    expect(readContractsMock).toHaveBeenCalledTimes(1);
     expect(res1['0x1']).toEqual([1n, 2n]);
 
     const res2 = await fetchReserves(pools, 1n);
-    expect(multicallMock).toHaveBeenCalledTimes(1); // cached
+    expect(readContractsMock).toHaveBeenCalledTimes(1); // cached
     expect(res2['0x2']).toEqual([3n, 4n]);
   });
 });


### PR DESCRIPTION
## Summary
- replace viemClient.multicall with publicClient.readContracts for reserve lookups
- update tests to mock readContracts and ensure caching logic remains

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689cd6dbd38c832a930ef4e0d738e982