### PR TITLE
Use Address-typed maps for token flow

### DIFF
--- a/packages/core/src/abie/simulation/simulateUnknownTx.ts
+++ b/packages/core/src/abie/simulation/simulateUnknownTx.ts
@@ -8,6 +8,7 @@ import type { TraceResult } from '@t-op-arb-bot/types';
 import { parseTrace } from "../../utils/traceParsers.js";
 import { traceCache } from "../../utils/traceCache.js";
 import { computeNetTokenFlow } from "../../utils/computeNetTokenFlow.js";
+import type { Address } from "viem";
 import { fetchTokenPrice } from "../../utils/fetchTokenPrice.js";
 import { computeSafeFlashLoanSize } from "../../utils/flashLoanSizing.js";
 import { fetchReserves } from "../../utils/fetchReserves.js";
@@ -71,7 +72,7 @@ export async function simulateUnknownTx({ txHash }: SimulationInput): Promise<Si
 
     // Flatten calls and compute net token flow
     const flat = flattenCalls(trace.calls || []);
-    const flows = computeNetTokenFlow(flat, trace.from);
+    const flows = computeNetTokenFlow(flat, trace.from as Address);
     const poolAddresses = Array.from(
       new Set(flat.map((c: any) => c.to).filter(Boolean))
     );

--- a/packages/core/src/utils/computeNetTokenFlow.ts
+++ b/packages/core/src/utils/computeNetTokenFlow.ts
@@ -1,10 +1,12 @@
-import type { Hex } from "viem";
+import type { Address, Hex } from "viem";
 
 interface TraceCall {
-  from: string;
-  to: string;
+  from: Address;
+  to: Address;
   input: Hex;
 }
+
+export type TokenFlow = Map<Address, bigint>;
 
 /**
  * Aggregates ERC-20 transfer/transferFrom calls and computes net token
@@ -13,33 +15,34 @@ interface TraceCall {
  */
 export function computeNetTokenFlow(
   calls: TraceCall[],
-  executor: string
-): Map<string, bigint> {
-  const flows = new Map<string, bigint>();
-  const exec = executor.toLowerCase();
+  executor: Address
+): TokenFlow {
+  const flows: TokenFlow = new Map();
+  const exec = executor.toLowerCase() as Address;
 
   for (const call of calls) {
     if (!call.input) continue;
     const input = call.input.toLowerCase();
     const selector = input.slice(0, 10);
-    const token = call.to.toLowerCase();
+    const token = call.to.toLowerCase() as Address;
 
     if (selector === "0xa9059cbb") {
       // transfer(address,uint256)
-      const to = "0x" + input.slice(34, 74);
+      const to = ("0x" + input.slice(34, 74)).toLowerCase() as Address;
       const amount = BigInt("0x" + input.slice(74, 138));
+      const from = call.from.toLowerCase() as Address;
       let net = flows.get(token) || 0n;
-      if (call.from.toLowerCase() === exec) net -= amount;
-      if (to.toLowerCase() === exec) net += amount;
+      if (from === exec) net -= amount;
+      if (to === exec) net += amount;
       flows.set(token, net);
     } else if (selector === "0x23b872dd") {
       // transferFrom(address,address,uint256)
-      const from = "0x" + input.slice(34, 74);
-      const to = "0x" + input.slice(98, 138);
+      const from = ("0x" + input.slice(34, 74)).toLowerCase() as Address;
+      const to = ("0x" + input.slice(98, 138)).toLowerCase() as Address;
       const amount = BigInt("0x" + input.slice(138, 202));
       let net = flows.get(token) || 0n;
-      if (from.toLowerCase() === exec) net -= amount;
-      if (to.toLowerCase() === exec) net += amount;
+      if (from === exec) net -= amount;
+      if (to === exec) net += amount;
       flows.set(token, net);
     }
   }


### PR DESCRIPTION
## Summary
- change token flow mapping to use Address keys instead of strings
- expose `TokenFlow` type and enforce Address executor parameter
- cast simulation trace sender to Address when computing token flows

## Testing
- `pnpm test`
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_689cf8daf090832a88614bf1487a0e95