### PR TITLE
test: mock debug client for trace

### DIFF
--- a/backend/src/simulateUnknownTx.test.ts
+++ b/backend/src/simulateUnknownTx.test.ts
@@ -36,9 +36,10 @@ describe('simulateUnknownTx', () => {
     vi.doMock('@blazing/core/utils/fetchReserves', () => ({ fetchReserves: vi.fn().mockResolvedValue({}) }));
 
     const { simulateUnknownTx } = await import('@blazing/core/abie/simulation/simulateUnknownTx');
+    const { debugClient } = await import('@blazing/core/clients/viemClient');
     const result = await simulateUnknownTx({ txHash: '0xabc' });
 
-    expect(debugTraceMock).toHaveBeenCalled();
+    expect(debugClient.traceTransaction).toHaveBeenCalled();
     expect(decodeSelectorMock).toHaveBeenCalled();
     expect(result?.trace).toBeTruthy();
     expect(result?.profit).toBeNull();


### PR DESCRIPTION
## Summary
- mock `debugClient.traceTransaction` in simulateUnknownTx tests
- assert `debugClient` was invoked when tracing transactions

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689d094f50c8832abc262ece0bdbe3c0