### PR TITLE
docs: document clients and tracing separation

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -1,2 +1,7 @@
 # Architecture
 Explanation of modules, data flow, and bundling process.
+
+## Clients & Tracing
+The bot uses two separate RPC clients. A `publicClient` handles standard read operations, while a `debugClient` is dedicated to tracing.
+
+When tracing, `debugClient.traceTransaction` delegates its JSON-RPC calls to `publicClient.request`, allowing traces to reuse the same transport as regular reads.


### PR DESCRIPTION
## Summary
- document separation of `publicClient` for reads and `debugClient` for tracing
- note that `debugClient.traceTransaction` delegates to `publicClient.request`

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config file)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689d0d1dedf0832ab02128e07d1c2b8e