### PR TITLE
chore: convert type-only imports

### DIFF
--- a/packages/core/src/abie/broadcaster/broadcastHooks.ts
+++ b/packages/core/src/abie/broadcaster/broadcastHooks.ts
@@ -1,7 +1,8 @@
 // src/abie/broadcaster/broadcastHooks.ts
 
 import { broadcastABIEEvent } from './abieBroadcaster.js';
-import { ABIE_EVENT_TYPES, ABIEEventPayloads } from './eventTypes.js';
+import { ABIE_EVENT_TYPES } from './eventTypes.js';
+import type { ABIEEventPayloads } from './eventTypes.js';
 
 /**
  * Helper functions to emit standardized ABIE event broadcasts.

--- a/packages/core/src/core/metaConsolidator.ts
+++ b/packages/core/src/core/metaConsolidator.ts
@@ -6,7 +6,7 @@
  */
 
 import { JsonRpcProvider, Contract } from 'ethers';
-import { CanonicalPair } from './pairFormatter.js';
+import type { CanonicalPair } from './pairFormatter.js';
 
 const ERC20_ABI = [
   { name: 'decimals', type: 'function', inputs: [], outputs: [{ type: 'uint8' }], stateMutability: 'view' },

--- a/packages/core/src/core/pairFormatter.ts
+++ b/packages/core/src/core/pairFormatter.ts
@@ -5,7 +5,7 @@
  * and removes duplicates from multiple DEXs or redundant listings.
  */
 
-import { RawLP } from '../dex/dexCollector.js';
+import type { RawLP } from '../dex/dexCollector.js';
 
 export interface CanonicalPair {
   tokenA: string;

--- a/packages/core/src/core/scanDiscrepancy.ts
+++ b/packages/core/src/core/scanDiscrepancy.ts
@@ -1,5 +1,5 @@
 import { computeSpread } from '../utils/computeSpread.js';
-import { SpreadComputationResult } from '../types/arbitrageTypes.js';
+import type { SpreadComputationResult } from '../types/arbitrageTypes.js';
 
 export interface DexSnapshot {
   pairSymbol: string;

--- a/packages/core/src/core/strategyBuilder.ts
+++ b/packages/core/src/core/strategyBuilder.ts
@@ -1,7 +1,7 @@
 import type { ArbStrategy } from '../types/strategyTypes.js';
 import { withFlashloan } from './mixins/withFlashloan.js';
 import { withPermit2 } from './mixins/withPermit2.js';
-import { ExecutionResult } from '../monitorExecution.js';
+import type { ExecutionResult } from '../monitorExecution.js';
 
 export interface GuardrailConfig {
   minProfitUSD: number;

--- a/packages/core/src/dex/loaders/sushiswap.ts
+++ b/packages/core/src/dex/loaders/sushiswap.ts
@@ -8,7 +8,7 @@
 import { JsonRpcProvider, Contract } from 'ethers';
 import { SUSHISWAP_FACTORY_ABI } from '../../abi-cache/FACTORY/sushiswapV2Factory.js';
 import { SUSHISWAP_PAIR_ABI } from '../../abi-cache/PAIR/sushiswapV2Pair.js';
-import { RawLP } from '../dexCollector.js';
+import type { RawLP } from '../dexCollector.js';
 
 const SUSHISWAP_FACTORY_ADDRESS = '0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac'; // SushiSwap V2 Factory
 const RPC_URL = process.env.INFURA_MAINNET || '';

--- a/packages/core/src/dex/loaders/uniswap.ts
+++ b/packages/core/src/dex/loaders/uniswap.ts
@@ -8,7 +8,7 @@
 import { JsonRpcProvider, Contract } from 'ethers';
 import { UNISWAP_FACTORY_ABI } from '../../abi-cache/FACTORY/uniswapV2Factory.js';
 import { UNISWAP_PAIR_ABI } from '../../abi-cache/PAIR/uniswapV2Pair.js';
-import { RawLP } from '../dexCollector.js';
+import type { RawLP } from '../dexCollector.js';
 
 const UNISWAP_FACTORY_ADDRESS = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'; // Uniswap V2 Factory
 const RPC_URL = process.env.INFURA_MAINNET || ''; // Use .env for config

--- a/packages/core/src/hooks/postDiscrepancyHooks.ts
+++ b/packages/core/src/hooks/postDiscrepancyHooks.ts
@@ -1,7 +1,7 @@
 // src/hooks/postDiscrepancyHooks.ts
 
-import { SpreadComputationResult } from '../types/arbitrageTypes.js';
-import { SyncTrace } from '../types/SyncTrace.js';
+import type { SpreadComputationResult } from '../types/arbitrageTypes.js';
+import type { SyncTrace } from '../types/SyncTrace.js';
 import { emitArbOpportunity, emitSystemLog } from '../abie/broadcaster/broadcastHooks.js';
 
 /**

--- a/packages/core/src/hooks/postExecutionHooks.ts
+++ b/packages/core/src/hooks/postExecutionHooks.ts
@@ -1,7 +1,7 @@
 // src/hooks/postExecutionHooks.ts
 
-import { ExecutionResult } from "../monitorExecution.js";
-import { ArbStrategy } from "../types/strategyTypes.js";
+import type { ExecutionResult } from "../monitorExecution.js";
+import type { ArbStrategy } from "../types/strategyTypes.js";
 
 import {
   emitExecutionResult,

--- a/packages/core/src/hooks/postSyncHooks.ts
+++ b/packages/core/src/hooks/postSyncHooks.ts
@@ -7,9 +7,9 @@ import { profitGuard } from '../utils/profitGuard.js';
 import { postExecutionHooks } from './postExecutionHooks.js';
 
 import { emitSyncEvent, emitArbOpportunity } from '../abie/broadcaster/broadcastHooks.js';
-import { SyncEventLog } from '../types/SyncTrace.js';
-import { ArbStrategy } from '../types/strategyTypes.js';
-import { ExecutionResult } from '../monitorExecution.js';
+import type { SyncEventLog } from '../types/SyncTrace.js';
+import type { ArbStrategy } from '../types/strategyTypes.js';
+import type { ExecutionResult } from '../monitorExecution.js';
 
 /**
  * Invoked after an LP Sync event is received.

--- a/packages/core/src/integration/pipeline.integration.test.ts
+++ b/packages/core/src/integration/pipeline.integration.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { scanDiscrepancy, DexSnapshot } from '../core/scanDiscrepancy.js';
+import { scanDiscrepancy } from '../core/scanDiscrepancy.js';
+import type { DexSnapshot } from '../core/scanDiscrepancy.js';
 import * as hooks from '../abie/broadcaster/broadcastHooks.js';
 
 class OpportunityHeap {

--- a/packages/core/src/types/strategyTypes.ts
+++ b/packages/core/src/types/strategyTypes.ts
@@ -1,4 +1,4 @@
-import { ExecutionResult } from '../monitorExecution.js';
+import type { ExecutionResult } from '../monitorExecution.js';
 
 export interface ArbStrategy {
   pairSymbol?: string;

--- a/packages/core/src/utils/parseTrace.ts
+++ b/packages/core/src/utils/parseTrace.ts
@@ -1,7 +1,7 @@
 // src/utils/parseTrace.ts
 
 import type { TraceResult } from '@t-op-arb-bot/types';
-import { DecodedCallData } from "@/types/decodedTypes.js";
+import type { DecodedCallData } from "@/types/decodedTypes.js";
 
 interface ViemTraceCall {
   type: string;

--- a/packages/core/src/ws/broadcaster.ts
+++ b/packages/core/src/ws/broadcaster.ts
@@ -6,7 +6,7 @@
  */
 
 import { WebSocket, WebSocketServer } from 'ws';
-import { TokenMeta } from '../core/metaConsolidator.js';
+import type { TokenMeta } from '../core/metaConsolidator.js';
 
 const PORT = process.env.WS_PORT ? parseInt(process.env.WS_PORT) : 8081;
 


### PR DESCRIPTION
## Summary
- fix TS1484 by converting type-only imports across modules

## Testing
- `pnpm test` *(fails: Cannot find package '@/clients/viemClient.js')*
- `pnpm typecheck` *(fails: None of the selected packages has a "typecheck" script)*
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689dad1c1d18832ab50b9f0a460cf297