### PR TITLE
chore: guard wss clients access

### DIFF
--- a/packages/core/src/abie/commands/commandHandlers.ts
+++ b/packages/core/src/abie/commands/commandHandlers.ts
@@ -86,8 +86,10 @@ const COMMAND_REGISTRY: Record<ABIECommand, CommandHandler> = {
  * Utility snapshot for reporting how many clients are connected.
  */
 function WebSocketServerSnapshot() {
+  const clients = globalThis.wss?.clients;
+
   return {
     time: Date.now(),
-    connected: globalThis['wss']?.clients?.size ?? 'unknown'
+    connected: clients?.size ?? 'unknown'
   };
 }

--- a/packages/core/src/types/global.d.ts
+++ b/packages/core/src/types/global.d.ts
@@ -3,13 +3,15 @@
 
 export {};
 
+type WsLike = { clients?: Set<unknown> } | undefined;
+
 declare global {
   /**
    * Global WS server/client handle used by command handlers.
    * Prefer a typed singleton module; this is a minimal unblock for builds that reference `globalThis.wss`.
    */
   // eslint-disable-next-line no-var
-  var wss: unknown | undefined;
+  var wss: WsLike;
 }
 
 /**


### PR DESCRIPTION
## Summary
- guard global WebSocket server clients
- type global `wss` for safer access

## Testing
- `pnpm test` (fails: Cannot find package '@/clients/viemClient.js')
- `pnpm typecheck` (fails: no typecheck script)
- `pnpm lint` (fails: ESLint couldn't find an eslint config)


------
https://chatgpt.com/codex/tasks/task_e_689db9a5ac34832aa155f22a90ed2ab4