### PR TITLE
Guard slippage update when profit missing

### DIFF
--- a/packages/core/src/hooks/postExecutionHooks.ts
+++ b/packages/core/src/hooks/postExecutionHooks.ts
@@ -51,7 +51,7 @@ export async function postExecutionHooks({ strategy, result }: PostExecutionCont
   });
 
   // 3. Adaptive tuning — optionally adjust slippage based on result
-  if (status === "success") {
+  if (status === "success" && profitAchieved) {
     updateSlippageTolerance(strategy.pairSymbol, profitAchieved);
   }
 


### PR DESCRIPTION
## Summary
- ensure `updateSlippageTolerance` is only called when `profitAchieved` is defined

## Testing
- `pnpm typecheck` *(no typecheck scripts)*
- `pnpm test` *(fails: Cannot find package '@/abie/broadcaster/eventTypes.js')*

------
https://chatgpt.com/codex/tasks/task_e_689dbb619764832a9ebad89b8ff55d00