### PR TITLE
fix: allow undefined cache keys

### DIFF
--- a/packages/core/src/utils/abiCache.ts
+++ b/packages/core/src/utils/abiCache.ts
@@ -26,17 +26,19 @@ class LRUCache<K, V> {
     } catch {}
   }
 
-  get(key: K): V | undefined {
+  get(key: K | undefined): V | undefined {
+    if (key === undefined) return undefined;
     if (!this.cache.has(key)) return undefined;
-    const val = this.cache.get(key)!;
-    this.cache.delete(key);
-    this.cache.set(key, val);
+    const val = this.cache.get(key as K)!;
+    this.cache.delete(key as K);
+    this.cache.set(key as K, val);
     return val;
   }
 
-  set(key: K, value: V) {
-    if (this.cache.has(key)) this.cache.delete(key);
-    this.cache.set(key, value);
+  set(key: K | undefined, value: V) {
+    if (key === undefined) return;
+    if (this.cache.has(key as K)) this.cache.delete(key as K);
+    this.cache.set(key as K, value);
     if (this.cache.size > this.limit) {
       const first = this.cache.keys().next().value;
       this.cache.delete(first);

--- a/packages/core/src/utils/traceCache.ts
+++ b/packages/core/src/utils/traceCache.ts
@@ -25,17 +25,19 @@ class LRUCache<K, V> {
     } catch {}
   }
 
-  get(key: K): V | undefined {
+  get(key: K | undefined): V | undefined {
+    if (key === undefined) return undefined;
     if (!this.cache.has(key)) return undefined;
-    const val = this.cache.get(key)!;
-    this.cache.delete(key);
-    this.cache.set(key, val);
+    const val = this.cache.get(key as K)!;
+    this.cache.delete(key as K);
+    this.cache.set(key as K, val);
     return val;
   }
 
-  set(key: K, value: V) {
-    if (this.cache.has(key)) this.cache.delete(key);
-    this.cache.set(key, value);
+  set(key: K | undefined, value: V) {
+    if (key === undefined) return;
+    if (this.cache.has(key as K)) this.cache.delete(key as K);
+    this.cache.set(key as K, value);
     if (this.cache.size > this.limit) {
       const first = this.cache.keys().next().value;
       this.cache.delete(first);


### PR DESCRIPTION
## Summary
- ignore undefined keys in ABI and trace caches

## Testing
- `pnpm test` *(fails: Cannot find package '@/clients/viemClient.js')*

------
https://chatgpt.com/codex/tasks/task_e_689dbd1a9f88832ab31b9cd089219939