### PR TITLE
fix: add null guard to decodeSelector

### DIFF
--- a/packages/core/src/utils/decodeSelector.ts
+++ b/packages/core/src/utils/decodeSelector.ts
@@ -13,6 +13,9 @@ export function decodeSelector(selector: string, callData: string, abi?: Interfa
   try {
     const iface = new Interface(entry);
     const fragment = iface.getFunction(selector);
+    if (!fragment) {
+      return null;
+    }
     const decoded = iface.decodeFunctionData(fragment, callData);
     return { method: fragment.name, args: Array.from(decoded) };
   } catch {


### PR DESCRIPTION
## Summary
- avoid TypeScript errors in decodeSelector by guarding missing ABI fragments

## Testing
- `pnpm test` *(fails: Cannot find package '@/clients/viemClient.js')*
- `pnpm typecheck` *(fails: None of the selected packages has a "typecheck" script)*
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689dbecf19b4832a87551c9397d795ae