### PR TITLE
test: cast pool addresses and mock multicall

### DIFF
--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     alias: {
       '@backend': path.resolve(__dirname, './src'),
       '@blazing/core': path.resolve(__dirname, '../packages/core/src'),
+      '@': path.resolve(__dirname, '../packages/core/src'),
       '@types': path.resolve(__dirname, '../packages/types/src'),
       '@t-op-arb-bot/types': path.resolve(__dirname, '../packages/types/src'),
     },

--- a/packages/core/src/utils/fetchReserves.test.ts
+++ b/packages/core/src/utils/fetchReserves.test.ts
@@ -5,28 +5,34 @@ beforeEach(() => {
 });
 
 describe('fetchReserves', () => {
-  it('uses readContracts and caches per block', async () => {
-    const readContractsMock = vi.fn().mockResolvedValue([
+  it('uses multicall and caches per block', async () => {
+    const multicallMock = vi.fn().mockResolvedValue([
       [1n, 2n, 0n],
       [3n, 4n, 0n],
     ]);
     vi.doMock('../clients/viemClient', () => ({
-      publicClient: { readContracts: readContractsMock },
+      publicClient: { multicall: multicallMock },
     }));
 
     const { fetchReserves, clearReserveCache } = await import('./fetchReserves.js');
     clearReserveCache();
 
-    const pools = ['0x1', '0x2'];
-    const res1 = await fetchReserves(pools, 1n);
-    expect(readContractsMock).toHaveBeenCalledTimes(1);
+    const pools = ['0x1', '0x2'] as const;
+    const res1 = await fetchReserves(
+      pools as readonly `0x${string}`[],
+      { blockNumber: 1n },
+    );
+    expect(multicallMock).toHaveBeenCalledTimes(1);
     expect(res1).toEqual({
       '0x1': [1n, 2n],
       '0x2': [3n, 4n],
     });
 
-    const res2 = await fetchReserves(pools, 1n);
-    expect(readContractsMock).toHaveBeenCalledTimes(1); // cached
+    const res2 = await fetchReserves(
+      pools as readonly `0x${string}`[],
+      { blockNumber: 1n },
+    );
+    expect(multicallMock).toHaveBeenCalledTimes(1); // cached
     expect(res2).toEqual(res1);
   });
 });

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -1,6 +1,11 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname,
+    },
+  },
   test: {
     passWithNoTests: true,
     include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],


### PR DESCRIPTION
## Summary
- mock multicall in `fetchReserves` tests and cast pool addresses to template literal types
- resolve `@` alias in core and backend vitest configs

## Testing
- `pnpm --filter @blazing/core test`
- `pnpm test` *(fails: expected undefined to deeply equal { token, amount })*


------
https://chatgpt.com/codex/tasks/task_e_689e0f4667d4832aa778d3acf1820a94