### PR TITLE
Send WebSocket auth token and fix post-execution hooks

### DIFF
--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -49,9 +49,9 @@ export function useWebSocket(enabled = true) {
   })();
 
   const forcedMode = import.meta.env.VITE_WS_AUTH_MODE as AuthMode | undefined;
-  const authModeRef = useRef<AuthMode>(
-    forcedMode ?? (resolvedToken ? 'query' : 'none')
-  );
+  // Default to sending the token as a query parameter; fall back modes are
+  // retained for logging but the handshake will always include the token.
+  const authModeRef = useRef<AuthMode>(forcedMode ?? 'query');
 
   useEffect(() => {
     mountedRef.current = true;
@@ -84,17 +84,15 @@ export function useWebSocket(enabled = true) {
 
     if (wsRef.current) return; // already connecting/connected
 
-    const openSocket = (mode: AuthMode): WebSocket => {
+    const openSocket = (_mode: AuthMode): WebSocket => {
       const urlObj = new URL(rawBase);
-      if (mode === 'query' && resolvedToken) {
-        // Don't duplicate token if already present in the base URL
+      if (resolvedToken) {
+        // Ensure the token is always sent. Append as a query param (avoids proxy
+        // stripping) and also advertise it via subprotocol for servers that
+        // expect an Authorization header.
         if (!urlObj.searchParams.get('token')) {
           urlObj.searchParams.set('token', resolvedToken);
         }
-        return new WebSocket(urlObj.toString());
-      }
-      if (mode === 'subprotocol' && resolvedToken) {
-        // Browser cannot set Authorization header; subprotocol is the alternative
         return new WebSocket(urlObj.toString(), ['bearer', resolvedToken]);
       }
       return new WebSocket(urlObj.toString());
@@ -111,27 +109,14 @@ export function useWebSocket(enabled = true) {
       reconnectTimerRef.current = window.setTimeout(connect, delay);
     };
 
-    const maybeToggleAuthMode = () => {
-      if (forcedMode) return; // honor explicit mode
-      if (!resolvedToken) return;
-
-      authModeRef.current =
-        authModeRef.current === 'query'
-          ? 'subprotocol'
-          : authModeRef.current === 'subprotocol'
-          ? 'query'
-          : 'query';
-    };
-
     const connect = () => {
       if (!mountedRef.current) return;
 
       const mode = authModeRef.current;
 
-      // If an auth mode requiring a token is selected but we have no token, bail (avoid spam).
-      if ((mode === 'query' || mode === 'subprotocol') && !resolvedToken) {
+      if (!resolvedToken) {
         console.warn(
-          `[WS] ${mode} auth selected but no token found. Set VITE_WS_TOKEN or include ?token= in VITE_WS_URL (.env.local).`
+          '[WS] no auth token found. Set VITE_WS_TOKEN or include ?token= in VITE_WS_URL (.env.local).'
         );
         setStatus('disconnected');
         return;
@@ -144,7 +129,6 @@ export function useWebSocket(enabled = true) {
         ws = openSocket(mode);
       } catch (err) {
         console.error('[WS] constructor failed:', err);
-        maybeToggleAuthMode();
         scheduleReconnect();
         return;
       }
@@ -191,8 +175,7 @@ export function useWebSocket(enabled = true) {
 
         // Handshake/auth rejections in browsers are often surfaced as 1006 (no clean close).
         if (e.code === 1006 || e.code === 1008 || /unauth|auth|policy|401/i.test(e.reason)) {
-          maybeToggleAuthMode();
-          scheduleReconnect(true); // immediate retry with alternate mode
+          scheduleReconnect(true); // immediate retry
         } else {
           scheduleReconnect();
         }

--- a/packages/core/src/hooks/postExecutionHooks.ts
+++ b/packages/core/src/hooks/postExecutionHooks.ts
@@ -2,22 +2,19 @@
 
 // Re-export so tests can spy via this module
 export { emitExecutionResult, emitRevertAlert } from '@/abie/broadcaster/broadcastHooks.js';
+export { logToDatabase } from '@/utils/dbLogger.js';
+export { updateSlippageTolerance } from '@/config/arbitrageConfig.js';
 
 // Local aliases used internally
 import {
   emitExecutionResult as _emitExecutionResult,
   emitRevertAlert as _emitRevertAlert,
+  emitSystemLog as _emitSystemLog,
 } from '@/abie/broadcaster/broadcastHooks.js';
-
-/** Exported so tests can spy; noop until wired to a real DB. */
-export async function logToDatabase(_entry: { txHash: string; trace?: unknown }): Promise<void> {
-  /* noop */
-}
-
-/** Optional tuning stub */
-export function updateSlippageTolerance(_pair: string, _profit: unknown): void {
-  /* noop */
-}
+import { logToDatabase } from '@/utils/dbLogger.js';
+import { updateSlippageTolerance } from '@/config/arbitrageConfig.js';
+import { simulateUnknownTx } from '@/abie/simulation/simulateUnknownTx.js';
+import { formatTraceForLogs } from '@/utils/formatTraceForLogs.js';
 
 /** Helpers */
 function toProfitString(p: unknown): string {
@@ -51,6 +48,15 @@ export async function onExecutionSuccess(args: {
     profit: toProfitString(args.profit),
     gasUsed: args.gasUsed ?? '0',
   });
+
+  updateSlippageTolerance(args.pair, toProfitString(args.profit));
+
+  const sim = await simulateUnknownTx({ txHash: args.txHash });
+  if (sim?.trace) {
+    const formatted = formatTraceForLogs(sim.trace);
+    console.log(formatted);
+    _emitSystemLog(formatted);
+  }
 }
 
 /** Method 2: revert handler (tests call this directly) */


### PR DESCRIPTION
## Summary
- include auth token in WebSocket handshake using query and subprotocol
- wire post execution hooks to log, tune slippage, and emit trace system logs

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3cb9c17b4832ab36d6ae59f21f92d