### PR TITLE
feat(env): support frontend origins and env mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Sample environment configuration
+
+# Node execution environment (optional)
+NODE_ENV=development
+
+# Comma-separated list of allowed frontend origins
+FRONTEND_ORIGINS=http://localhost:5173
+
+# Port for the backend WebSocket server
+WS_PORT=8081
+
+# Optional: archive node URL for local fork scripts
+RPC_ARCHIVE=https://your-archive-node.example
+# Optional: block number to fork from
+FORK_BLOCK_NUMBER=0

--- a/backend/src/config/env.test.ts
+++ b/backend/src/config/env.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { safeParse } from 'valibot';
-import { EnvSchema } from './env.js';
+import { EnvSchema, env, setEnv } from './env.js';
 
 describe('EnvSchema', () => {
   it('parses valid environment', () => {
@@ -23,5 +23,22 @@ describe('EnvSchema', () => {
       CHAIN_ID: 'foo',
     });
     expect(result.success).toBe(false);
+  });
+
+  it('transforms optional fields', () => {
+    const result = safeParse(EnvSchema, {
+      RPC_HTTP_URL: 'http://localhost:8545',
+      RPC_WSS_URL: 'ws://localhost:8546',
+      CHAIN_ID: '1',
+      WS_AUTH_TOKEN: 'secret',
+      WS_PORT: '9000',
+      FRONTEND_ORIGINS: 'http://foo,http://bar',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      setEnv(result.output);
+      expect(env.WS_PORT).toBe(9000);
+      expect(env.FRONTEND_ORIGINS).toEqual(['http://foo', 'http://bar']);
+    }
   });
 });

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -33,6 +33,9 @@ const booleanFromString = (defaultValue: boolean) =>
   );
 
 export const EnvSchema = v.object({
+  NODE_ENV: v.optional(v.string()),
+  FRONTEND_ORIGINS: v.optional(v.string()),
+  WS_PORT: v.optional(v.string()),
   RPC_HTTP_URL: v.pipe(v.string(), v.url()),
   RPC_WSS_URL: v.pipe(v.string(), v.url()),
   CHAIN_ID: v.pipe(
@@ -42,7 +45,6 @@ export const EnvSchema = v.object({
     v.integer(),
     v.minValue(1),
   ),
-  WS_PORT: nonNegIntFromString(8080),
   HTTP_PORT: nonNegIntFromString(3000),
   LOG_LEVEL: v.pipe(
     v.optional(v.picklist(['fatal', 'error', 'warn', 'info', 'debug', 'trace'] as const)),
@@ -76,8 +78,21 @@ export const EnvSchema = v.object({
   TRACE_BROADCAST_ENABLED: booleanFromString(false),
 });
 
-export type Env = v.InferOutput<typeof EnvSchema>;
+export type RawEnv = v.InferOutput<typeof EnvSchema>;
+export type Env = Omit<RawEnv, 'WS_PORT' | 'FRONTEND_ORIGINS'> & {
+  WS_PORT: number;
+  FRONTEND_ORIGINS: string[];
+};
 export let env: Env;
-export function setEnv(e: Env): void {
-  env = e;
+export function setEnv(e: RawEnv): void {
+  const wsPort = e.WS_PORT ? Number.parseInt(e.WS_PORT, 10) : 8080;
+  const origins = e.FRONTEND_ORIGINS
+    ? e.FRONTEND_ORIGINS.split(',').map((s) => s.trim()).filter(Boolean)
+    : [];
+  const { WS_PORT: _, FRONTEND_ORIGINS: __, ...rest } = e;
+  env = {
+    ...rest,
+    WS_PORT: Number.isFinite(wsPort) ? wsPort : 8080,
+    FRONTEND_ORIGINS: origins,
+  };
 }


### PR DESCRIPTION
## Summary
- parse optional NODE_ENV and FRONTEND_ORIGINS env vars
- handle WS_PORT as string in schema with numeric transform in setEnv
- document sample env values

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3f2b2452c832aacd8eb51481a9f7d