### PR TITLE
feat: add websocket auth check endpoint

### DIFF
--- a/backend/src/server/http.test.ts
+++ b/backend/src/server/http.test.ts
@@ -60,3 +60,36 @@ describe('GET /opportunities', () => {
     expect(data.entries[0]).toHaveProperty('pairSymbol');
   });
 });
+
+describe('GET /ws-auth-check', () => {
+  it('returns 200 for valid token', async () => {
+    server = startHttpServer(0);
+    await new Promise((r) => server.on('listening', r));
+    const port = getPort();
+    const res = await fetch(`http://127.0.0.1:${port}/ws-auth-check?token=secret`);
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects invalid token', async () => {
+    server = startHttpServer(0);
+    await new Promise((r) => server.on('listening', r));
+    const port = getPort();
+    const res = await fetch(`http://127.0.0.1:${port}/ws-auth-check?token=bad`);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid/);
+  });
+
+  it('enforces FRONTEND_ORIGINS allow-list', async () => {
+    setEnv({ ...baseEnv, FRONTEND_ORIGINS: 'https://allowed.io' as any });
+    server = startHttpServer(0);
+    await new Promise((r) => server.on('listening', r));
+    const port = getPort();
+    const res = await fetch(`http://127.0.0.1:${port}/ws-auth-check?token=secret`, {
+      headers: { Origin: 'https://not.io' },
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/origin/);
+  });
+});

--- a/backend/src/server/http.ts
+++ b/backend/src/server/http.ts
@@ -94,6 +94,42 @@ export function startHttpServer(port = env.HTTP_PORT) {
       return;
     }
 
+    if (req.method === 'GET' && req.url?.startsWith('/ws-auth-check')) {
+      try {
+        const url = new URL(req.url, `http://${req.headers.host}`);
+        const token = url.searchParams.get('token');
+        const origin = String(req.headers.origin ?? '');
+
+        if (
+          env.FRONTEND_ORIGINS.length > 0 &&
+          !env.FRONTEND_ORIGINS.includes(origin)
+        ) {
+          res.writeHead(403, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'origin not allowed' }));
+          return;
+        }
+
+        if (!token) {
+          res.writeHead(401, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'missing token' }));
+          return;
+        }
+
+        if (token !== env.WS_AUTH_TOKEN) {
+          res.writeHead(401, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'invalid token' }));
+          return;
+        }
+
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+      } catch {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'invalid request' }));
+      }
+      return;
+    }
+
     if (req.method === 'GET' && req.url?.startsWith('/quote')) {
       try {
         const url = new URL(req.url, `http://${req.headers.host}`);


### PR DESCRIPTION
## Summary
- add GET /ws-auth-check endpoint to validate WS tokens and origins
- test ws auth check endpoint for success, bad tokens, and origin restrictions

## Testing
- `pnpm --filter backend test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a3f6725ed4832a966305795c4159b8