### PR TITLE
feat(frontend): add ws auth preflight

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { useWebSocket } from './hooks/useWebSocket';
 import LivePairsTable from './components/LivePairsTable';
 import Header from './components/Header';
 import NotificationArea from './components/NotificationArea';
+import PreflightButton from './components/PreflightButton';
 import { useAccount } from 'wagmi';
 
 export default function App() {
@@ -13,6 +14,7 @@ export default function App() {
     <div>
       <Header />
       <NotificationArea />
+      <PreflightButton />
       {isConnected ? (
         <div>
           <h1>Frontend</h1>

--- a/frontend/src/components/NotificationArea.tsx
+++ b/frontend/src/components/NotificationArea.tsx
@@ -23,7 +23,8 @@ export default function NotificationArea() {
             marginBottom: '0.5rem',
             padding: '0.5rem 1rem',
             borderRadius: '0.25rem',
-            backgroundColor: n.type === 'error' ? '#fdd' : '#ffd',
+            backgroundColor:
+              n.type === 'error' ? '#fdd' : n.type === 'success' ? '#dfd' : '#ffd',
             color: '#000',
           }}
         >

--- a/frontend/src/components/PreflightButton.tsx
+++ b/frontend/src/components/PreflightButton.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { maskToken } from '../hooks/useWebSocket';
+import { useNotificationStore } from '../useNotificationStore';
+
+function resolveToken(): string | undefined {
+  const rawBase = (import.meta.env.VITE_WS_URL as string | undefined) ?? '';
+  const envToken =
+    (import.meta.env.VITE_WS_TOKEN as string | undefined) ??
+    (import.meta.env.VITE_WS_AUTH_TOKEN as string | undefined);
+  try {
+    const fromBase = rawBase ? new URL(rawBase).searchParams.get('token') : null;
+    const fromPage =
+      typeof window !== 'undefined'
+        ? new URL(window.location.href).searchParams.get('wsToken') ??
+          new URL(window.location.href).searchParams.get('token')
+        : null;
+    const fromStorage =
+      typeof window !== 'undefined'
+        ? localStorage.getItem('WS_TOKEN') ??
+          localStorage.getItem('VITE_WS_TOKEN') ??
+          sessionStorage.getItem('WS_TOKEN')
+        : null;
+    return envToken ?? fromBase ?? fromPage ?? fromStorage ?? undefined;
+  } catch {
+    return envToken ?? undefined;
+  }
+}
+
+export default function PreflightButton() {
+  const addNotification = useNotificationStore((s) => s.add);
+  const [loading, setLoading] = useState(false);
+
+  const run = async () => {
+    const token = resolveToken();
+    if (!token) {
+      addNotification({ type: 'error', message: 'missing token' });
+      return;
+    }
+    setLoading(true);
+    try {
+      console.info('[Preflight] GET /ws-auth-check', { token: maskToken(token) });
+      const res = await fetch(`/ws-auth-check?token=${encodeURIComponent(token)}`);
+      if (res.ok) {
+        addNotification({ type: 'success', message: 'ws auth ok' });
+      } else if (res.status === 401 || res.status === 403) {
+        let err = '';
+        try { err = (await res.json()).error; } catch {}
+        addNotification({ type: 'error', message: `${res.status} ${err}`.trim() });
+      } else {
+        addNotification({ type: 'error', message: `error ${res.status}` });
+      }
+    } catch (e) {
+      console.error('[Preflight] failed', e);
+      addNotification({ type: 'error', message: 'preflight failed' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <button onClick={run} disabled={loading} style={{ marginLeft: '1rem' }}>
+      {loading ? 'Preflighting…' : 'Preflight'}
+    </button>
+  );
+}

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -7,7 +7,7 @@ import { useArbStore } from '../useArbStore';
 export let openSocket = (url: string, token: string) =>
   new WebSocket(url, [`token:${token}`, 'json']);
 
-function maskToken(t?: string | null) {
+export function maskToken(t?: string | null) {
   if (!t) return '';
   if (t.length <= 10) return '•••';
   return `${t.slice(0, 6)}…${t.slice(-4)}`;

--- a/frontend/src/useNotificationStore.ts
+++ b/frontend/src/useNotificationStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 
 export type Notification = {
   id: number;
-  type: 'warning' | 'error';
+  type: 'warning' | 'error' | 'success';
   message: string;
 };
 


### PR DESCRIPTION
## Summary
- add Preflight button to call `GET /ws-auth-check`
- show success or 401/403 messages via notifications
- export `maskToken` helper to ensure any logged token is masked

## Testing
- `pnpm -F frontend lint`
- `pnpm -F frontend test`
- `pnpm -F frontend build`


------
https://chatgpt.com/codex/tasks/task_e_68a42b51ab30832ab4cec5f0fc6c3536